### PR TITLE
Ter certeza que a cidade existe no cadastro, ignorar exceptions localmente

### DIFF
--- a/api/lib/Penhas/CEP/ViaCep.pm
+++ b/api/lib/Penhas/CEP/ViaCep.pm
@@ -17,11 +17,17 @@ sub _find {
     return unless $res->is_success;
 
     my $r = eval { decode_json($res->content) } or return;
+    return if $r->{erro};
 
     my $street = $r->{logradouro} || '';
 
-    return {street => $street, city => $r->{localidade}, district => $r->{bairro}, state => $r->{uf},
-        ibge => $r->{ibge}};
+    return {
+        street   => $street,
+        city     => $r->{localidade},
+        district => $r->{bairro},
+        state    => $r->{uf},
+        ibge     => $r->{ibge}
+    };
 }
 
 1;

--- a/api/lib/Penhas/Controller/SignUp.pm
+++ b/api/lib/Penhas/Controller/SignUp.pm
@@ -83,14 +83,16 @@ sub post {
         eval {
             foreach my $backend (map { Penhas::CEP->new_with_traits(traits => $_) } qw(ViaCep Correios)) {
                 my @_address_fields = qw(city state);
-                $result = $backend->find($cep);
+                $result = eval{$backend->find($cep)};
+                $c->log->error("Error during cep find using $backend: $@") if ($@);
+
                 if ($result) {
 
                     # para o teste dos backend se todos os campos estão preenchidos
                     last if (grep { length $result->{$_} } @_address_fields) == @_address_fields;
                 }
             }
-            if (!$result) {
+            if (!$result || !$result->{city}) {
                 $err = {
                     error   => 'cep_invalid',
                     message => "Não conseguimos localizar o endereço do CEP $cep!",

--- a/api/lib/Penhas/Minion/Tasks/CepUpdater.pm
+++ b/api/lib/Penhas/Minion/Tasks/CepUpdater.pm
@@ -34,7 +34,8 @@ sub cliente_update_cep {
     $cep =~ s/[^0-9]//go;
     my $result;
     foreach my $backend (map { Penhas::CEP->new_with_traits(traits => $_) } qw(ViaCep Correios)) {
-        $result = $backend->find($cep);
+        $result = eval{$backend->find($cep)};
+        $logger->error("Error during cep find using $backend: $@") if $@;
         if ($result) {
 
             # pula proximo backend se todos os campos estão preenchidos


### PR DESCRIPTION
Corrige o comportamento onde uma exception (por exemplo, timeout) poderia fazer com que os próximos backends não fossem testados (eg: correios)

