### PR TITLE
[SYNC-MF] API para manual de fuga

### DIFF
--- a/api/lib/Penhas/Controller.pm
+++ b/api/lib/Penhas/Controller.pm
@@ -194,6 +194,11 @@ sub validate_request_params {
     my ($c, %fields) = @_;
 
     my $params = $c->req->params->to_hash;
+    return validate_params($c, $params, %fields);
+}
+
+sub validate_params {
+    my ($c, $params, %fields) = @_;
 
     my $tested = {};
     foreach my $key (keys %fields) {
@@ -252,8 +257,9 @@ sub validate_request_params {
         }
 
         $tested->{$key} = $val;
-        if ($tested->{$key} eq '' && ($type eq 'Bool' || $type eq 'Int' || $type eq 'Num')) {
-            use DDP; p $val;
+        if (defined $tested->{$key} && $tested->{$key} eq '' && ($type eq 'Bool' || $type eq 'Int' || $type eq 'Num')) {
+            use DDP;
+            p $val;
             $tested->{$key} = undef;
 
         }

--- a/api/lib/Penhas/Controller/Maintenance.pm
+++ b/api/lib/Penhas/Controller/Maintenance.pm
@@ -119,6 +119,17 @@ sub housekeeping {
 "
     );
 
+    $dbh->do(
+        "UPDATE cliente_mf_session_control SET
+        status = 'onboarding',
+        current_clientes_quiz_session = null,
+        completed_questionnaires_id = '{}'
+        WHERE now() - started_at > '30 days'::interval
+        AND status='inProgress';
+"
+    );
+
+
     my $err = '';
     $err .= 'failed redis' unless Penhas::KeyValueStorage->instance->redis->ping() eq 'PONG';
 
@@ -222,7 +233,7 @@ sub _tick_notifications {
         $ENV{LAST_CHAT_JOB_ID} = $job_id;
     }
 
-    return $c->render(json => {});
+    return 1;
 }
 
 sub fix_tweets_parent_id {

--- a/api/lib/Penhas/Controller/Me_Quiz.pm
+++ b/api/lib/Penhas/Controller/Me_Quiz.pm
@@ -33,12 +33,42 @@ sub process {
         );
     }
 
+    if ($session_id && $session_id eq $user_obj->mf_redo_addr_session_id()) {
+        my $return = $c->process_redo_addr_mf_assistant(user_obj => $user_obj, params => $params);
+
+        return $c->render(
+            json   => $return,
+            status => 200,
+        );
+    }
+
+    if ($session_id && $session_id eq $user_obj->mf_assistant_session_id()) {
+        my $return = $c->process_mf_assistant(user_obj => $user_obj, params => $params);
+
+        return $c->render(
+            json   => $return,
+            status => 200,
+        );
+    }
+
     # se nao for a chave pra assistente, precisa ser um inteiro
     $c->validate_request_params(
         session_id => {required => 1, type => 'Int'},
     );
 
-    my $quiz_session = $c->user_get_quiz_session(user => $user);
+    my $mf_sc                         = $user_obj->ensure_cliente_mf_session_control_exists();
+    my $current_clientes_quiz_session = $mf_sc->current_clientes_quiz_session();                 #XXXXXXXXX
+
+    # se estiver respondendo o MF, carregamos ele se o Session ID der match no pedido, vamos nele,
+    # senão, vai na logica normal [procurar o primeiro chat relevante].
+    # pq isso só aqui no POST?
+    # o conteudo do chat vem sempre via GET /me, ou /me/chat ou /me/tarefas
+    # e ai já tbm tem os tratamentos pra carregar da session apropriadas
+
+    my $quiz_session = $c->user_get_quiz_session(
+        user       => $user,
+        session_id => $session_id,
+    );
 
     if (!$quiz_session) {
         return $c->render(

--- a/api/lib/Penhas/Controller/Me_Tarefas.pm
+++ b/api/lib/Penhas/Controller/Me_Tarefas.pm
@@ -1,0 +1,190 @@
+package Penhas::Controller::Me_Tarefas;
+use Mojo::Base 'Penhas::Controller';
+
+use DateTime;
+use Penhas::Types qw/TweetID/;
+
+use Penhas::Logger;
+use JSON qw/from_json to_json/;
+
+sub assert_user_perms {
+    my $c = shift;
+
+    $c->assert_user_has_module('tweets');
+    return 1;
+}
+
+
+sub me_t_list {
+    my $c = shift;
+
+    my $consultado_em = time();
+    my $params        = $c->req->params->to_hash;
+    my $valid         = $c->validate_request_params(
+        modificado_apos => {required => 1, type => 'Int'},
+    );
+
+    my $result = $c->cliente_lista_tarefas(
+        user_obj => $c->stash('user_obj'),
+        %$valid,
+    );
+
+    slog_info('tarefas ok');
+
+    return $c->render(
+        json => {
+            %$result,
+            %{$c->cliente_mf_assistant(user_obj => $c->stash('user_obj'))},
+            consultado_em => $consultado_em,
+        },
+        status => 200,
+    );
+}
+
+sub _sync_validate_and_process_params {
+    my $c      = shift;
+    my $params = shift;
+
+    my $valid;
+    if ($params->{remove}) {
+        $valid = $c->validate_params(
+            $params,
+            id     => {required => 1, type => 'Int'},
+            remove => {required => 1, type => 'Bool'},
+        );
+    }
+    else {
+        $valid = $c->validate_params(
+            $params,
+            id             => {required => 1, type => 'Int'},
+            checkbox_feito => {required => 1, type => 'Bool'},
+            campo_livre    => {required => 0, type => 'Str', max_length => 50000, empty_is_valid => 1},
+        );
+
+        if ($valid->{campo_livre}) {
+            my $decoded = eval { from_json($valid->{campo_livre}) };
+            if ($@) {
+                die {
+                    error   => 'form_error',
+                    field   => 'campo_livre',
+                    reason  => 'invalid',
+                    message => 'json inválido',
+                    status  => 400
+                };
+            }
+        }
+    }
+
+    return $valid;
+}
+
+sub _sync_perform_actions {
+    my $c     = shift;
+    my $valid = shift;
+
+    $c->app->log->debug('running _sync_perform_actions with ' . to_json($valid));
+
+    my $result = $c->cliente_sync_lista_tarefas(
+        user_obj => $c->stash('user_obj'),
+        %$valid,
+    );
+
+    return $result;
+}
+
+sub me_t_batch_sync {
+    my $c = shift;
+
+    my $params = $c->req->json;
+    die {
+        error   => 'form_error',
+        field   => 'body',
+        reason  => 'invalid',
+        message => 'INVALID JSON, body must be an array!',
+        status  => 400
+    } if (ref $params ne 'ARRAY');
+
+    $c->app->log->debug('raw parsed json params as ' . to_json($params));
+
+    my $updated = 0;
+    my $removed = 0;
+
+    $c->schema2->txn_do(
+        sub {
+            for my $param (@$params) {
+                use DDP; p $param;
+                if (exists $param->{campo_livre} && ref $param->{campo_livre}) {
+                    $param->{campo_livre} = to_json($param->{campo_livre});
+                }
+
+                my $form = _sync_validate_and_process_params($c, $param);
+                $c->app->log->debug('processed form as ' . to_json($form));
+
+                _sync_perform_actions($c, $form);
+
+                if ($form->{remove}) {
+                    $removed++;
+                }
+                else {
+                    $updated++;
+                }
+            }
+        }
+    );
+
+    return $c->render(
+        json => {
+            updated => $updated,
+            removed => $removed,
+        },
+        status => 200,
+    );
+}
+
+
+sub me_t_sync {
+    my $c = shift;
+
+    my $params = $c->req->params->to_hash;
+
+    my $valid = _sync_validate_and_process_params($c, $params);
+
+    _sync_perform_actions($c, $valid);
+
+    return $c->render(
+        text   => '',
+        status => 204,
+    );
+}
+
+
+sub me_t_nova {
+
+    my $c = shift;
+
+    my $params = $c->req->params->to_hash;
+
+    my $valid = $c->validate_request_params(
+        titulo    => {required => 1, type => 'Str', max_length => 512,  min_length => 1,},
+        descricao => {required => 1, type => 'Str', max_length => 2048, min_length => 1},
+        agrupador => {required => 1, type => 'Str', max_length => 120,  min_length => 1},
+        token     => {required => 1, type => 'Str', max_length => 120,  min_length => 1},
+
+
+        # enviar 1 pra mudar o tipo para [checkbox_contato]
+        checkbox_contato => {required => 0, type => 'Bool'},
+    );
+
+    my $result = $c->cliente_nova_tarefas(
+        user_obj => $c->stash('user_obj'),
+        %$valid,
+    );
+
+    return $c->render(
+        json   => $result,
+        status => 200,
+    );
+}
+
+
+1;

--- a/api/lib/Penhas/Helpers/Cliente.pm
+++ b/api/lib/Penhas/Helpers/Cliente.pm
@@ -3,18 +3,453 @@ use common::sense;
 use Carp qw/confess /;
 use utf8;
 
-use JSON;
+use JSON qw/from_json to_json/;
 use Penhas::Logger;
 use Penhas::Utils;
 use DateTime::Format::Pg;
 use Encode;
 
+our $NEW_TASK_TOKEN = $ENV{NEW_TASK_TOKEN} || '';
+
+my $descricao
+  = 'O Manual de Fuga vai ajudá-la a criar um plano de saída do ambiente doméstico. Por isso, dedique um tempo, e responda ao máximo de perguntas, para podermos personalizar uma lista de ações essenciais para o seu planejamento. Ela será mostrada somente depois que você concluir a interação.';
+
 sub setup {
     my $self = shift;
 
-    $self->helper('add_report_profile' => sub { &add_report_profile(@_) });
-    $self->helper('add_block_profile'  => sub { &add_block_profile(@_) });
-    $self->helper('remove_blocked_profile'  => sub { &remove_blocked_profile(@_) });
+    $self->helper('add_report_profile'     => sub { &add_report_profile(@_) });
+    $self->helper('add_block_profile'      => sub { &add_block_profile(@_) });
+    $self->helper('remove_blocked_profile' => sub { &remove_blocked_profile(@_) });
+
+    $self->helper('cliente_lista_tarefas'      => sub { &cliente_lista_tarefas(@_) });
+    $self->helper('cliente_sync_lista_tarefas' => sub { &cliente_sync_lista_tarefas(@_) });
+    $self->helper('cliente_nova_tarefas'       => sub { &cliente_nova_tarefas(@_) });
+    $self->helper('cliente_mf_assistant'       => sub { &cliente_mf_assistant(@_) });
+
+    $self->helper('cliente_mf_add_tarefa_por_codigo' => sub { &cliente_mf_add_tarefa_por_codigo(@_) });
+    $self->helper('cliente_mf_add_tag_by_code'       => sub { &cliente_mf_add_tag_by_code(@_) });
+    $self->helper('cliente_mf_clear_tasks'           => sub { &cliente_mf_clear_tasks(@_) });
+
+}
+
+sub cliente_mf_assistant {
+    my ($c, %opts) = @_;
+
+    my $user = $opts{user_obj} or confess 'missing user_obj';
+    return {} unless $user->is_female();
+
+    slog_info('calling ensure_cliente_mf_session_control_exists');
+    my $mf_sc = $user->ensure_cliente_mf_session_control_exists();
+
+    my $config = {
+        'onboarding' => {t => 'Criar o meu Manual de Fuga',         d => $descricao},
+        'inProgress' => {t => 'Continuar preenchendo o meu Manual', d => $descricao},
+        'completed'  => {t => 'Refazer o meu Manual de Fuga',       d => $descricao},
+    };
+    slog_info('returned $mf_sc->status() = ' . $mf_sc->status());
+
+    my $title    = $config->{$mf_sc->status()}{t};
+    my $subtitle = $config->{$mf_sc->status()}{d};
+
+    # no onboarding e completed o body é vazio, precisa de um POST /me/quiz (só precisa passar o session_id)
+    # para iniciar a session com o primeiro valor da mf_questionnaire_order (geralmente o B0)
+    my $quiz_session = {
+        current_msgs => [],
+        prev_msgs    => undef
+    };
+
+    slog_info('calling current_clientes_quiz_session');
+    my $mf_current_session_id = $mf_sc->get_column('current_clientes_quiz_session');
+    if ($mf_current_session_id) {
+        slog_info('calling user_get_quiz_session with session_id=%s', $mf_current_session_id);
+
+        $quiz_session = $c->user_get_quiz_session(
+            user       => {$user->get_columns()},
+            session_id => $mf_current_session_id
+        );
+
+        if (!$quiz_session) {
+            slog_info(
+                'failed to load current_clientes_quiz_session user=%s $mf_current_session_id=%s',
+                $user->id, $mf_current_session_id,
+            );
+            $user->remove_cliente_mf_session_control();
+        }
+        else {
+            slog_info('calling load_quiz_session');
+
+            $c->load_quiz_session(session => $quiz_session, user => {$user->get_columns()}, user_obj => $user);
+
+            $quiz_session = $c->stash('quiz_session');
+        }
+    }
+
+    my $ret = {
+        title    => $title,
+        subtitle => $subtitle,
+
+        quiz_session => {
+            session_id => $user->mf_assistant_session_id(),
+            %$quiz_session,
+        }
+    };
+
+
+    return {mf_assistant => $ret};
+}
+
+sub cliente_mf_clear_tasks {
+    my ($c, %opts) = @_;
+
+    my $user = $opts{user_obj} or confess 'missing user_obj';
+
+    $c->schema2->resultset('MfClienteTarefa')->search(
+        {
+            removido_em => undef,
+            cliente_id  => $user->id,
+        }
+    )->update({removido_em => \'now()'});
+
+
+}
+
+
+sub cliente_mf_add_tag_by_code {
+    my ($c, %opts) = @_;
+
+    my $user    = $opts{user_obj} or confess 'missing user_obj';
+    my $codigos = $opts{codigos}  or confess 'missing codigos';
+
+    $c->schema2->txn_do(
+        sub {
+            my @tarefas = $c->schema2->resultset('MfTag')->search(
+                {
+                    code => {in => $codigos},
+                },
+                {
+                    result_class => 'DBIx::Class::ResultClass::HashRefInflator',
+                    columns      => ['id', 'code'],
+                }
+            )->all;
+
+            my @already_exists = $c->schema2->resultset('ClienteTag')->search(
+                {
+                    cliente_id => $user->id,
+
+                    mf_tag_id => {'in' => [map { $_->{id} } @tarefas]}
+                },
+                {
+                    result_class => 'DBIx::Class::ResultClass::HashRefInflator',
+                    columns      => ['mf_tag_id']
+                }
+            )->all();
+
+            my $exists_by_id = {};
+            $exists_by_id->{$_->{mf_tag_id}} = 1 for @already_exists;
+
+            for my $tarefa (@tarefas) {
+                next if $exists_by_id->{$tarefa->{id}};
+
+                slog_info(
+                    'adding mf_cliente_tag user=%s $mf_tag_id=%s %s',
+                    $user->id, $tarefa->{id}, $tarefa->{code},
+                );
+
+                $c->schema2->resultset('ClienteTag')->create(
+                    {
+                        cliente_id => $user->id,
+                        created_on => \'now()',
+                        mf_tag_id  => $tarefa->{id},
+                    }
+                );
+            }
+        }
+    );
+}
+
+sub cliente_mf_add_tarefa_por_codigo {
+    my ($c, %opts) = @_;
+
+    my $user    = $opts{user_obj} or confess 'missing user_obj';
+    my $codigos = $opts{codigos}  or confess 'missing codigos';
+
+    $c->schema2->txn_do(
+        sub {
+            my @tarefas = $c->schema2->resultset('MfTarefa')->search(
+                {
+                    codigo => {in => $codigos},
+                },
+                {
+                    result_class => 'DBIx::Class::ResultClass::HashRefInflator',
+                    columns      => ['id', 'codigo'],
+                }
+            )->all;
+
+            my @already_exists = $c->schema2->resultset('MfClienteTarefa')->search(
+                {
+                    removido_em => undef,
+                    cliente_id  => $user->id,
+
+                    mf_tarefa_id => {'in' => [map { $_->{id} } @tarefas]}
+                },
+                {
+                    result_class => 'DBIx::Class::ResultClass::HashRefInflator',
+                    columns      => ['mf_tarefa_id']
+                }
+            )->all();
+
+            my $exists_by_id = {};
+            $exists_by_id->{$_->{mf_tarefa_id}} = 1 for @already_exists;
+
+            for my $tarefa (@tarefas) {
+                next if $exists_by_id->{$tarefa->{id}};
+
+                slog_info(
+                    'adding mf_cliente_tarefa user=%s $tarefa_id=%s %s',
+                    $user->id, $tarefa->{id}, $tarefa->{codigo},
+                );
+
+                $c->schema2->resultset('MfClienteTarefa')->create(
+                    {
+                        removido_em   => undef,
+                        cliente_id    => $user->id,
+                        atualizado_em => \'now()',
+                        mf_tarefa_id  => $tarefa->{id},
+                    }
+                );
+            }
+        }
+    );
+
+
+}
+
+# será usado apenas para o desenvolvimento, não será usado em produção
+# o token de prod não será setado, então ficara desabilitado
+sub cliente_nova_tarefas {
+    my ($c, %opts) = @_;
+
+    my $user      = $opts{user_obj} or confess 'missing user_obj';
+    my $titulo    = $opts{titulo};
+    my $descricao = $opts{descricao};
+    my $agrupador = $opts{agrupador};
+    my $token     = $opts{token};
+
+    die {
+        message => 'Token não confere',
+        error   => 'mftoken_invalid'
+      }
+      unless $NEW_TASK_TOKEN
+      && $token eq $NEW_TASK_TOKEN;
+
+
+    my $tipo           = 'checkbox';
+    my $eh_customizada = 'false';
+
+    if ($opts{checkbox_contato}) {
+        $tipo           = 'checkbox_contato';
+        $eh_customizada = 'true';
+    }
+
+    my $id;
+
+    $c->schema2->txn_do(
+        sub {
+            my $tarefa_id = $c->schema2->resultset('MfTarefa')->create(
+                {
+
+                    titulo         => $titulo,
+                    descricao      => $descricao,
+                    agrupador      => $agrupador,
+                    tipo           => $tipo,
+                    codigo         => '',
+                    eh_customizada => $eh_customizada,
+                }
+            );
+
+            $id = $c->schema2->resultset('MfClienteTarefa')->create(
+                {
+                    removido_em   => undef,
+                    cliente_id    => $user->id,
+                    atualizado_em => \'now()',
+                    mf_tarefa_id  => $tarefa_id->id(),
+                }
+            )->id();
+        }
+    );
+
+    return {message => 'entrada criada com sucesso!', id => $id};
+}
+
+sub cliente_lista_tarefas {
+    my ($c, %opts) = @_;
+
+    my $user            = $opts{user_obj} or confess 'missing user_obj';
+    my $modificado_apos = $opts{modificado_apos};
+
+    my $alteracoes = [
+        $c->schema2->resultset('MfClienteTarefa')->search(
+            {
+                removido_em => undef,
+                cliente_id  => $user->id,
+                '-and'      => [\['atualizado_em >= to_timestamp(?)', $modificado_apos]]
+            },
+            {prefetch => 'mf_tarefa'}
+        )->all
+    ];
+
+    my $tarefas_removidas = [
+        map { $_->{id} } $c->schema2->resultset('MfClienteTarefa')->search(
+            {
+                removido_em => {'!=' => undef},
+                cliente_id  => $user->id,
+                '-and'      => [\['removido_em >= to_timestamp(?)', $modificado_apos]]
+            },
+            {
+                select       => ['id'],
+                result_class => 'DBIx::Class::ResultClass::HashRefInflator'
+            }
+        )->all
+    ];
+
+    my @botoes = ();
+
+    # se já iniciou alguma vez
+    my $has_mf_sc = $c->schema2->resultset('ClienteMfSessionControl')->search(
+        {
+            cliente_id => $user->id,
+            status     => {'not in' => ['onboarding']}
+        }
+    )->count();
+    if ($has_mf_sc) {
+        push @botoes, &render_botao_endereco($user);
+    }
+
+    return {
+        tarefas => [
+            (map { &render_tarefa($_) } @$alteracoes),
+            @botoes
+        ],
+        tarefas_removidas => $tarefas_removidas
+    };
+
+}
+
+
+sub cliente_sync_lista_tarefas {
+    my ($c, %opts) = @_;
+
+    my $user = $opts{user_obj} or confess 'missing user_obj';
+
+    my $mf_id          = $opts{id};
+    my $checkbox_feito = $opts{checkbox_feito};
+
+    my $row = $c->schema2->resultset('MfClienteTarefa')->search(
+        {
+            'me.removido_em' => undef,
+            'me.cliente_id'  => $user->id,
+            'me.id'          => $mf_id
+        },
+        {prefetch => 'mf_tarefa'}
+    )->next;
+    die {
+        message => 'Não foi possível encontrar a tarefa.',
+        error   => 'mfclientetarefa_id_not_found'
+    } unless $row;
+
+    if ($opts{remove}) {
+        $row->update({removido_em => \'now()'});
+
+        return {message => 'Removido com sucesso.'};
+    }
+
+    my $campo_livre = ($opts{campo_livre} ? $opts{campo_livre} : undef);
+    $campo_livre = to_json($campo_livre) if (defined $campo_livre && ref $campo_livre);
+
+    $c->schema2->txn_do(
+        sub {
+            if ($row->mf_tarefa->eh_customizada) {
+
+                $row->update(
+                    {
+                        atualizado_em => \'now()',
+                        campo_livre   => $campo_livre,
+                    }
+                );
+            }
+            elsif (!$row->mf_tarefa->eh_customizada && $campo_livre) {
+                $c->app->log->debug(
+                    'cliente_sync_lista_tarefas chamado com campo livre mas tarefa não é eh_customizada. Valor ignorado'
+                      . to_json($campo_livre));
+            }
+
+            # se mudou o valor do checkbox
+            if (!!$row->checkbox_feito() ne !!$checkbox_feito) {
+                $row->update(
+                    {
+                        checkbox_feito => $checkbox_feito ? 'true' : 'false',
+                        atualizado_em  => \'now()',
+
+                        $checkbox_feito
+                        ? (
+                            # guarda a primeira vez que marcou como feito
+                            $row->checkbox_feito_checked_first_updated_at() ? () : (
+                                checkbox_feito_checked_first_updated_at => \'now()',
+                            ),
+
+                            # e a ultima vez que marcou como feito
+                            checkbox_feito_checked_last_updated_at => \'now()'
+                          )
+                        : (
+                            # guarda a primeria vez que como não-feito
+                            $row->checkbox_feito_unchecked_first_updated_at() ? () : (
+                                checkbox_feito_unchecked_first_updated_at => \'now()',
+                            ),
+
+                            # e a ultima vez que marcou como não-feito
+                            checkbox_feito_unchecked_last_updated_at => \'now()'
+                        )
+                    }
+                );
+            }
+        }
+    );
+
+    return {message => 'Atualizado com sucesso.'};
+}
+
+
+sub render_tarefa {
+    my ($mf_cliente_tarefa) = @_;
+
+    my $mf_tarefa = $mf_cliente_tarefa->mf_tarefa;
+    return {
+        id             => $mf_cliente_tarefa->id(),
+        checkbox_feito => $mf_cliente_tarefa->checkbox_feito(),
+        atualizado_em  => $mf_cliente_tarefa->atualizado_em->epoch(),
+        campo_livre    => ($mf_cliente_tarefa->campo_livre() ? from_json($mf_cliente_tarefa->campo_livre()) : undef),
+        tipo           => $mf_tarefa->tipo(),
+        eh_customizada => $mf_tarefa->eh_customizada(),
+        titulo         => $mf_tarefa->titulo(),
+        descricao      => $mf_tarefa->descricao(),
+        agrupador      => $mf_tarefa->agrupador(),
+    };
+}
+
+sub render_botao_endereco {
+    my ($user) = @_;
+
+    return {
+        id            => -1,
+        atualizado_em => time(),
+        tipo          => 'button',
+        descricao     => '',
+        agrupador     => 'Transporte',
+        data          => {
+            label => 'Revisar Transporte',
+            route => '/quiz/start?session_id=' . $user->mf_redo_addr_session_id(),
+        }
+    };
 }
 
 sub add_block_profile {

--- a/api/lib/Penhas/Routes.pm
+++ b/api/lib/Penhas/Routes.pm
@@ -53,6 +53,9 @@ sub register {
     # GET /web/faq/_botao_contato_
     $faq->get('_botao_contato_')->to(action => 'webfaq_botao_contato');
 
+    # GET /web/faq/conta-exclusao
+    $faq->get('conta-exclusao')->to(action => 'webfaq_conta_exclusao');
+
     # GET /web/termos-de-uso
     $web->get('termos-de-uso')->to(action => 'web_termos_de_uso');
 
@@ -147,6 +150,7 @@ sub register {
     $me->put()->to(action => 'me_update');
     $me->delete()->to(action => 'me_delete');
 
+
     # GET /me/delete-text
     $me->get('delete-text')->to(controller => 'Me', action => 'me_delete_text');
 
@@ -158,6 +162,9 @@ sub register {
 
     # POST /me/call-police-pressed
     $me->post('call-police-pressed')->to(action => 'inc_call_police_counter');
+
+    # POST /me/inc-login-offline
+    $me->post('inc-login-offline')->to(action => 'inc_login_offline_counter');
 
     # POST /me/modo-anonimo-toggle
     $me->post('modo-anonimo-toggle')->to(action => 'route_cliente_modo_anonimo_toggle');
@@ -182,6 +189,15 @@ sub register {
     # /me/media
     my $me_media = $me->under('media')->to(controller => 'Me_Media', action => 'assert_user_perms');
     $me_media->post()->to(action => 'upload');
+
+    # /me/tarefas
+    my $me_tarefas = $me->under('tarefas')->to(controller => 'Me_Tarefas', action => 'assert_user_perms');
+
+    $me_tarefas->get()->to(action => 'me_t_list');
+    $me_tarefas->post('sync')->to(action => 'me_t_sync');
+    $me_tarefas->post('nova')->to(action => 'me_t_nova');
+    $me_tarefas->post('batch')->to(action => 'me_t_batch_sync');
+
 
     # /me/tweets
     my $me_tweets = $me->under('tweets')->to(controller => 'Me_Tweets', action => 'assert_user_perms');

--- a/api/lib/Penhas/Schema.pm
+++ b/api/lib/Penhas/Schema.pm
@@ -50,18 +50,6 @@ SQL_QUERY
 
 use DateTime::Format::DateParse;
 
-sub now {
-    my $self = shift;
-
-    my $now = $self->storage->dbh_do(
-        sub {
-            DateTime::Format::DateParse->parse_datetime($_[1]->selectrow_array('SELECT replaceable_now()'));
-        }
-    );
-
-    return $now;
-}
-
 sub unaccent {
     my $self = shift;
     my $text = shift;

--- a/api/lib/Penhas/Schema2/Result/ClienteBloqueio.pm
+++ b/api/lib/Penhas/Schema2/Result/ClienteBloqueio.pm
@@ -21,11 +21,17 @@ __PACKAGE__->add_columns(
   "cliente_id",
   { data_type => "bigint", is_foreign_key => 1, is_nullable => 0 },
   "blocked_cliente_id",
-  { data_type => "bigint", is_nullable => 0 },
+  { data_type => "bigint", is_foreign_key => 1, is_nullable => 0 },
   "created_at",
   { data_type => "timestamp with time zone", is_nullable => 0 },
 );
 __PACKAGE__->set_primary_key("id");
+__PACKAGE__->belongs_to(
+  "blocked_cliente",
+  "Penhas::Schema2::Result::Cliente",
+  { id => "blocked_cliente_id" },
+  { is_deferrable => 0, on_delete => "SET NULL", on_update => "NO ACTION" },
+);
 __PACKAGE__->belongs_to(
   "cliente",
   "Penhas::Schema2::Result::Cliente",
@@ -34,8 +40,8 @@ __PACKAGE__->belongs_to(
 );
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-05-24 16:42:31
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:S5BNtU4ssKQ3MqYKkwCe0Q
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-05-25 21:16:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:7i11xpxGGqQyunA+JXxp4A
 
 # ALTER TABLE cliente_bloqueios ADD FOREIGN KEY (cliente_id) REFERENCES clientes(id) ON DELETE CASCADE ON UPDATE cascade;
 

--- a/api/lib/Penhas/Schema2/Result/ClienteMfSessionControl.pm
+++ b/api/lib/Penhas/Schema2/Result/ClienteMfSessionControl.pm
@@ -1,0 +1,180 @@
+#<<<
+use utf8;
+package Penhas::Schema2::Result::ClienteMfSessionControl;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'Penhas::Schema::Base';
+__PACKAGE__->table("cliente_mf_session_control");
+__PACKAGE__->add_columns(
+  "cliente_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "status",
+  {
+    data_type     => "text",
+    default_value => "onboarding",
+    is_nullable   => 0,
+    original      => { data_type => "varchar" },
+  },
+  "current_clientes_quiz_session",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  "completed_questionnaires_id",
+  {
+    data_type     => "integer[]",
+    default_value => \"'{}'::integer[]",
+    is_nullable   => 0,
+  },
+  "started_at",
+  {
+    data_type     => "timestamp",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "completed_at",
+  { data_type => "timestamp", is_nullable => 1 },
+);
+__PACKAGE__->set_primary_key("cliente_id");
+__PACKAGE__->belongs_to(
+  "cliente",
+  "Penhas::Schema2::Result::Cliente",
+  { id => "cliente_id" },
+  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
+);
+__PACKAGE__->belongs_to(
+  "current_clientes_quiz_session",
+  "Penhas::Schema2::Result::ClientesQuizSession",
+  { id => "current_clientes_quiz_session" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+#>>>
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2023-06-16 03:00:24
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:HU6o12q180TXkn/uKyPqMQ
+
+use Penhas::Logger;
+
+# -- statuses:
+# -- onboarding
+# -- inProgress
+# -- completed
+
+use Penhas::Utils;
+
+sub register_session_start {
+    my ($self, %opts) = @_;
+
+    $self->update(
+        {
+            started_at                    => \'now()',
+            current_clientes_quiz_session => $opts{session_id},
+            status                        => 'inProgress'
+        }
+    );
+
+    $self->prepare_for_questionnaire(questionnaire_id => $opts{questionnaire_id});
+}
+
+sub prepare_for_questionnaire {
+    my ($self, %opts) = @_;
+
+    my $questionnaire_id = $opts{questionnaire_id};
+    slog_info('prepare_for_questionnaire %s', $questionnaire_id);
+
+    # verifica a tabela mf_questionnaire_remove_tarefa e limpar os dados das tarefas se existir algum bloco
+    # marcado que quando entrar precisa remover
+
+    my @to_remove_tasks = $self->result_source->schema->resultset('MfQuestionnaireRemoveTarefa')
+      ->search({questionnaire_id => $questionnaire_id}, {result_class => 'DBIx::Class::ResultClass::HashRefInflator'});
+
+    if (@to_remove_tasks) {
+        @to_remove_tasks = map { $_->{codigo_tarefa} } @to_remove_tasks;
+        slog_info('@to_remove_tasks %s', join ', ', @to_remove_tasks);
+        my $clear_task = $self->result_source->schema->resultset('MfClienteTarefa')->search(
+            {
+                removido_em => undef,
+                cliente_id  => $self->cliente_id,
+
+                'mf_tarefa.codigo' => {'in' => \@to_remove_tasks}
+            },
+            {join => 'mf_tarefa'}
+        )->update({removido_em => \'now()'});
+
+        slog_info('$clear_task count=%s', $clear_task);
+    }
+}
+
+sub register_completed_questionnaire {
+    my ($self, %opts) = @_;
+
+    my $completed_questionnaires_id = [@{$self->completed_questionnaires_id}, $opts{questionnaire_id}];
+
+    $self->update(
+        {
+            completed_questionnaires_id => $completed_questionnaires_id,
+        }
+    );
+}
+
+# busca o proximo questionario que não foi completado
+sub get_next_questionnaire_id {
+    my ($self, %opts) = @_;
+    my $published = is_test() ? 'testing' : 'published';
+
+    my $outstanding = $opts{outstanding} ? $opts{outstanding} : 0;
+
+    my $completed_questionnaires_id = $self->completed_questionnaires_id;
+    $completed_questionnaires_id = [] unless $completed_questionnaires_id;
+
+    if ($outstanding) {
+
+        # busca pelo outstanding se não tiver sido respondido ainda
+        # isso é pra fazer pular na frente dos outros items
+        my $pending = $self->result_source->schema->resultset('MfQuestionnaireOrder')->search(
+            {
+                'me.published'         => $published,
+                'me.questionnaire_id'  => {'not in' => $completed_questionnaires_id},
+                'me.outstanding_order' => $outstanding
+            },
+            {order_by => 'sort', rows => 1}
+        )->get_column('questionnaire_id')->next;
+
+        return $pending if $pending;
+    }
+
+    # se não tiver, busca o normal
+    return $self->result_source->schema->resultset('MfQuestionnaireOrder')->search(
+        {
+            'me.published'        => $published,
+            'me.questionnaire_id' => {'not in' => $completed_questionnaires_id},
+        },
+        {order_by => 'sort', rows => 1}
+    )->get_column('questionnaire_id')->next;
+}
+
+sub set_status_completed {
+    my ($self, %opts) = @_;
+
+    $self->cliente->update({ja_completou_mf => 'true'}) unless $self->cliente->ja_completou_mf;
+
+    $self->update(
+        {
+            status                        => 'completed',
+            completed_at                  => \'now()',
+            completed_questionnaires_id   => '{}',
+            current_clientes_quiz_session => undef,
+        }
+    );
+}
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/api/lib/Penhas/Schema2/Result/ClienteTag.pm
+++ b/api/lib/Penhas/Schema2/Result/ClienteTag.pm
@@ -1,0 +1,54 @@
+#<<<
+use utf8;
+package Penhas::Schema2::Result::ClienteTag;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'Penhas::Schema::Base';
+__PACKAGE__->table("cliente_tag");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "cliente_tag_id_seq",
+  },
+  "cliente_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "mf_tag_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "created_on",
+  {
+    data_type     => "timestamp",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->add_unique_constraint("unique_cliente_tag", ["cliente_id", "mf_tag_id"]);
+__PACKAGE__->belongs_to(
+  "cliente",
+  "Penhas::Schema2::Result::Cliente",
+  { id => "cliente_id" },
+  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
+);
+__PACKAGE__->belongs_to(
+  "mf_tag",
+  "Penhas::Schema2::Result::MfTag",
+  { id => "mf_tag_id" },
+  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
+);
+#>>>
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2024-10-11 11:03:30
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:rWi3XgJORP+WZzicv8nO2w
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/api/lib/Penhas/Schema2/Result/ClientesQuizSession.pm
+++ b/api/lib/Penhas/Schema2/Result/ClientesQuizSession.pm
@@ -21,7 +21,7 @@ __PACKAGE__->add_columns(
   "cliente_id",
   { data_type => "bigint", is_foreign_key => 1, is_nullable => 0 },
   "questionnaire_id",
-  { data_type => "bigint", is_nullable => 0 },
+  { data_type => "bigint", is_foreign_key => 1, is_nullable => 0 },
   "finished_at",
   { data_type => "timestamp with time zone", is_nullable => 1 },
   "created_at",
@@ -42,10 +42,22 @@ __PACKAGE__->belongs_to(
   { id => "cliente_id" },
   { is_deferrable => 0, on_delete => "CASCADE", on_update => "CASCADE" },
 );
+__PACKAGE__->has_many(
+  "cliente_mf_session_controls",
+  "Penhas::Schema2::Result::ClienteMfSessionControl",
+  { "foreign.current_clientes_quiz_session" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->belongs_to(
+  "questionnaire",
+  "Penhas::Schema2::Result::Questionnaire",
+  { id => "questionnaire_id" },
+  { is_deferrable => 0, on_delete => "SET NULL", on_update => "NO ACTION" },
+);
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-05-24 16:42:31
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:yzHBGts476UcfEXaLqp3iA
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-05-25 21:16:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VN+g0sn6Chtsq8sRBZ1FwQ
 
 # ALTER TABLE clientes_quiz_session ADD FOREIGN KEY (cliente_id) REFERENCES clientes(id) ON DELETE CASCADE ON UPDATE cascade;
 

--- a/api/lib/Penhas/Schema2/Result/MfClienteTarefa.pm
+++ b/api/lib/Penhas/Schema2/Result/MfClienteTarefa.pm
@@ -1,0 +1,87 @@
+#<<<
+use utf8;
+package Penhas::Schema2::Result::MfClienteTarefa;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'Penhas::Schema::Base';
+__PACKAGE__->table("mf_cliente_tarefa");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "mf_cliente_tarefa_id_seq",
+  },
+  "mf_tarefa_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "cliente_id",
+  { data_type => "bigint", is_foreign_key => 1, is_nullable => 0 },
+  "checkbox_feito",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  "checkbox_feito_checked_first_updated_at",
+  { data_type => "timestamp", is_nullable => 1 },
+  "checkbox_feito_checked_last_updated_at",
+  { data_type => "timestamp", is_nullable => 1 },
+  "checkbox_feito_unchecked_first_updated_at",
+  { data_type => "timestamp", is_nullable => 1 },
+  "checkbox_feito_unchecked_last_updated_at",
+  { data_type => "timestamp", is_nullable => 1 },
+  "criado_em",
+  {
+    data_type     => "timestamp",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "removido_em",
+  { data_type => "timestamp", is_nullable => 1 },
+  "last_from_questionnaire",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  "atualizado_em",
+  {
+    data_type     => "timestamp",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "campo_livre",
+  { data_type => "json", is_nullable => 1 },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->belongs_to(
+  "cliente",
+  "Penhas::Schema2::Result::Cliente",
+  { id => "cliente_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+__PACKAGE__->belongs_to(
+  "last_from_questionnaire",
+  "Penhas::Schema2::Result::Questionnaire",
+  { id => "last_from_questionnaire" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+__PACKAGE__->belongs_to(
+  "mf_tarefa",
+  "Penhas::Schema2::Result::MfTarefa",
+  { id => "mf_tarefa_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+#>>>
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2024-03-01 01:40:23
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:YXtc84Pxq7SlVfLZffmEHA
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/api/lib/Penhas/Schema2/Result/MfQuestionnaireOrder.pm
+++ b/api/lib/Penhas/Schema2/Result/MfQuestionnaireOrder.pm
@@ -1,0 +1,51 @@
+#<<<
+use utf8;
+package Penhas::Schema2::Result::MfQuestionnaireOrder;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'Penhas::Schema::Base';
+__PACKAGE__->table("mf_questionnaire_order");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "mf_questionnaire_order_id_seq",
+  },
+  "sort",
+  { data_type => "integer", default_value => 0, is_nullable => 0 },
+  "outstanding_order",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  "is_last",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  "published",
+  {
+    data_type => "varchar",
+    default_value => "testing",
+    is_nullable => 1,
+    size => 20,
+  },
+  "questionnaire_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->belongs_to(
+  "questionnaire",
+  "Penhas::Schema2::Result::Questionnaire",
+  { id => "questionnaire_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+#>>>
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2024-10-11 11:03:30
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:V6TZ53X44e4xsqLo40ogrQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/api/lib/Penhas/Schema2/Result/MfQuestionnaireRemoveTarefa.pm
+++ b/api/lib/Penhas/Schema2/Result/MfQuestionnaireRemoveTarefa.pm
@@ -1,0 +1,44 @@
+#<<<
+use utf8;
+package Penhas::Schema2::Result::MfQuestionnaireRemoveTarefa;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'Penhas::Schema::Base';
+__PACKAGE__->table("mf_questionnaire_remove_tarefa");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "mf_questionnaire_remove_tarefa_id_seq",
+  },
+  "questionnaire_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "codigo_tarefa",
+  {
+    data_type   => "text",
+    is_nullable => 0,
+    original    => { data_type => "varchar" },
+  },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->belongs_to(
+  "questionnaire",
+  "Penhas::Schema2::Result::Questionnaire",
+  { id => "questionnaire_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+#>>>
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2024-02-01 12:18:11
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:gGX8I9dKx92uTAaesk7Aqw
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/api/lib/Penhas/Schema2/Result/MfTag.pm
+++ b/api/lib/Penhas/Schema2/Result/MfTag.pm
@@ -1,0 +1,56 @@
+#<<<
+use utf8;
+package Penhas::Schema2::Result::MfTag;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'Penhas::Schema::Base';
+__PACKAGE__->table("mf_tag");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "mf_tag_id_seq",
+  },
+  "code",
+  {
+    data_type   => "text",
+    is_nullable => 0,
+    original    => { data_type => "varchar" },
+  },
+  "description",
+  {
+    data_type   => "text",
+    is_nullable => 1,
+    original    => { data_type => "varchar" },
+  },
+  "created_on",
+  {
+    data_type     => "timestamp",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->add_unique_constraint("mf_tag_code_key", ["code"]);
+__PACKAGE__->has_many(
+  "cliente_tags",
+  "Penhas::Schema2::Result::ClienteTag",
+  { "foreign.mf_tag_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+#>>>
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2023-07-04 21:38:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Jp38iTkpj1ffeltewaVHaA
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/api/lib/Penhas/Schema2/Result/MfTarefa.pm
+++ b/api/lib/Penhas/Schema2/Result/MfTarefa.pm
@@ -1,0 +1,79 @@
+#<<<
+use utf8;
+package Penhas::Schema2::Result::MfTarefa;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'Penhas::Schema::Base';
+__PACKAGE__->table("mf_tarefa");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "mf_tarefa_id_seq",
+  },
+  "titulo",
+  {
+    data_type   => "text",
+    is_nullable => 0,
+    original    => { data_type => "varchar" },
+  },
+  "descricao",
+  {
+    data_type   => "text",
+    is_nullable => 0,
+    original    => { data_type => "varchar" },
+  },
+  "tipo",
+  {
+    data_type     => "text",
+    default_value => "checkbox",
+    is_nullable   => 0,
+    original      => { data_type => "varchar" },
+  },
+  "codigo",
+  {
+    data_type   => "text",
+    is_nullable => 1,
+    original    => { data_type => "varchar" },
+  },
+  "agrupador",
+  {
+    data_type => "varchar",
+    default_value => "Outros",
+    is_nullable => 0,
+    size => 120,
+  },
+  "criado_em",
+  {
+    data_type     => "timestamp",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "eh_customizada",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->has_many(
+  "mf_cliente_tarefas",
+  "Penhas::Schema2::Result::MfClienteTarefa",
+  { "foreign.mf_tarefa_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+#>>>
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2024-10-11 11:03:30
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zUxaAjLAUXqswT08Bn7TCg
+
+
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/api/lib/Penhas/Schema2/Result/Questionnaire.pm
+++ b/api/lib/Penhas/Schema2/Result/Questionnaire.pm
@@ -52,6 +52,36 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 __PACKAGE__->has_many(
+  "clientes_quiz_sessions",
+  "Penhas::Schema2::Result::ClientesQuizSession",
+  { "foreign.questionnaire_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->has_many(
+  "mf_cliente_tarefas",
+  "Penhas::Schema2::Result::MfClienteTarefa",
+  { "foreign.last_from_questionnaire" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->has_many(
+  "mf_questionnaire_orders",
+  "Penhas::Schema2::Result::MfQuestionnaireOrder",
+  { "foreign.questionnaire_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->has_many(
+  "mf_questionnaire_remove_tarefas",
+  "Penhas::Schema2::Result::MfQuestionnaireRemoveTarefa",
+  { "foreign.questionnaire_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->has_many(
+  "quiz_config_change_to_questionnaires",
+  "Penhas::Schema2::Result::QuizConfig",
+  { "foreign.change_to_questionnaire_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+__PACKAGE__->has_many(
   "quiz_configs",
   "Penhas::Schema2::Result::QuizConfig",
   { "foreign.questionnaire_id" => "self.id" },
@@ -59,8 +89,8 @@ __PACKAGE__->has_many(
 );
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-05-31 15:13:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:BwXh0aVH9ZzBT62SlFgwQg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2024-02-01 12:18:11
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:N8fpK94+TF1P3l/Rfe1l+Q
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/api/t/api/140-cliente-tarefa.t
+++ b/api/t/api/140-cliente-tarefa.t
@@ -1,0 +1,364 @@
+#!/usr/bin/perl
+# HARNESS-CONFLICTS CHAT
+
+use JSON;
+use Mojo::Base -strict;
+use FindBin qw($RealBin);
+use lib "$RealBin/../lib";
+use DateTime;
+use utf8;
+use Penhas::Test;
+use Penhas::Minion::Tasks::SendSMS;
+my $t = test_instance;
+use Business::BR::CPF qw/random_cpf/;
+use DateTime;
+use Penhas::Minion::Tasks::NewNotification;
+use Penhas::Utils qw/tt_test_condition tt_render/;
+my $schema2 = $t->app->schema2;
+
+my $now_datetime = DateTime->now()->datetime(' ');
+
+AGAIN:
+my $random_cpf   = random_cpf();
+my $random_email = 'email' . $random_cpf . '@something.com';
+goto AGAIN if cpf_already_exists($random_cpf);
+
+my $random_code = '_' . random_cpf();
+
+$ENV{FILTER_QUESTIONNAIRE_IDS} = '9999';
+$ENV{SKIP_END_NEWS}            = '1';
+
+$Penhas::Helpers::Cliente::NEW_TASK_TOKEN = 'new-task';
+
+my @other_fields = (
+    raca        => 'branco',
+    app_version => 'Versao Ios ou Android, Modelo Celular, Versao do App',
+    dry         => 0,
+);
+
+my $nome_completo = 'test tarefa';
+
+get_schema->resultset('CpfCache')->find_or_create(
+    {
+        cpf_hashed  => cpf_hash_with_salt($random_cpf),
+        dt_nasc     => '1994-01-31',
+        nome_hashed => cpf_hash_with_salt(uc $nome_completo),
+        situacao    => '',
+    }
+);
+
+my ($cliente_id, $session, $cliente);
+
+subtest_buffered 'Cadastro com sucesso' => sub {
+    my $res = $t->post_ok(
+        '/signup',
+        form => {
+            nome_completo => $nome_completo,
+            apelido       => 'cliente A',
+            cpf           => $random_cpf,
+            email         => $random_email,
+            senha         => 'ARUKEAS SS2',
+            cep           => '12345678',
+            dt_nasc       => '1994-01-31',
+            @other_fields,
+            genero      => rand() > 0.5 ? 'Feminino' : 'MulherTrans',
+            nome_social => 'foo bar',
+        },
+    )->status_is(200)->tx->res->json;
+
+    $cliente_id = $res->{_test_only_id};
+    $session    = $res->{session};
+    $cliente    = $schema2->resultset('Cliente')->find($cliente_id);
+};
+
+on_scope_exit { user_cleanup(user_id => [$cliente_id,]); };
+
+
+$t->get_ok('/filter-skills', {'x-api-key' => $session})->status_is(200);
+
+db_transaction {
+
+
+    is tt_test_condition("is_json_member('a', XXX)", {}), 0, 'is_json_member return false when reference do not exists';
+    is tt_test_condition("is_json_member('a', XXX)", {XXX => to_json(["a"])}), 1,
+      'is_json_member return true when item exists';
+    is tt_test_condition("is_json_member('b', XXX)", {XXX => to_json(["a"])}), 0,
+      'is_json_member return false when item is not found';
+
+    is tt_render("[% json_array_to_string(ref, 'me', 'skip') %]", {ref => to_json(["you", "it", "skip"])}),
+      'you, it e me',
+      'json_array_to_string is working';
+
+    $ENV{ENABLE_MANUAL_FUGA} = 0;
+    my $me_perfil = $t->get_ok(
+        '/me',
+        {'x-api-key' => $session},
+        form => {},
+    )->status_is(200, '')->tx->res->json;
+    my ($cnt) = grep { $_->{code} eq 'mf' } @{$me_perfil->{modules}};
+    is $cnt, undef, 'no mf module';
+
+    $ENV{ENABLE_MANUAL_FUGA} = 1;
+    $me_perfil = $t->get_ok(
+        '/me',
+        {'x-api-key' => $session},
+        form => {},
+    )->status_is(200, '')->tx->res->json;
+
+    my ($mf) = grep { $_->{code} eq 'mf' } @{$me_perfil->{modules}};
+    is $mf->{meta}{max_checkbox_contato}, 3, 'max_checkbox_contato=3';
+
+
+    my $mf_tarefa_rs         = $schema2->resultset('MfTarefa');
+    my $mf_cliente_tarefa_rs = $schema2->resultset('MfClienteTarefa');
+
+    my $tarefa_1_sistema = $mf_tarefa_rs->create(
+        {
+            titulo         => 'titulo 1',
+            descricao      => 'descricao 1',
+            tipo           => 'checkbox',
+            codigo         => $random_code,
+            eh_customizada => 'false',
+            agrupador      => 'nope'
+        }
+    );
+
+    my $epoch_start = time() - 20000;
+    $t->get_ok(
+        '/me/tarefas',
+        {'x-api-key' => $session},
+        form => {modificado_apos => $epoch_start},
+      )->status_is(200, 'busca todas as tarefas')    #
+      ->json_is('/tarefas', [], 'ainda sem nenhuma tarefa');
+
+
+    my $mfc1 = $mf_cliente_tarefa_rs->create(
+        {
+            mf_tarefa_id   => $tarefa_1_sistema->id,
+            cliente_id     => $cliente_id,
+            checkbox_feito => 'false',
+            atualizado_em  => \['to_timestamp(?)', $epoch_start + 1],
+        }
+    );
+
+    $t->get_ok(
+        '/me/tarefas',
+        {'x-api-key' => $session},
+        form => {modificado_apos => $epoch_start},
+      )->status_is(200, 'busca todas as tarefas')    #
+      ->json_is('/tarefas/0/id',             $mfc1->id, 'tarefa retornada')    #
+      ->json_is('/tarefas/0/titulo',         $tarefa_1_sistema->titulo)        #
+      ->json_is('/tarefas/0/descricao',      $tarefa_1_sistema->descricao)     #
+      ->json_is('/tarefas/0/checkbox_feito', '0')                              #
+      ->json_is('/tarefas/0/eh_customizada', '0')                              #
+      ->json_is('/tarefas/0/agrupador',      'nope')                           #
+      ->json_is('/tarefas/0/tipo',           $tarefa_1_sistema->tipo)          #
+      ->json_is('/tarefas/0/atualizado_em',  $epoch_start + 1)                 #
+      ;
+
+    $t->post_ok(
+        '/me/tarefas/sync',
+        {'x-api-key' => $session},
+        form => {
+            id             => $mfc1->id,
+            checkbox_feito => 1,
+        },
+    )->status_is(204, 'sync de task');
+
+    $t->get_ok(
+        '/me/tarefas',
+        {'x-api-key' => $session},
+        form => {modificado_apos => $epoch_start},
+    )->status_is(200, 'busca todas as tarefas desde um X momento')->json_is('/tarefas/0/checkbox_feito', '1');
+
+    $t->post_ok(
+        '/me/tarefas/sync',
+        {'x-api-key' => $session},
+        form => {
+            id             => $mfc1->id,
+            checkbox_feito => 0,
+        },
+    )->status_is(204, 'sync de task como não feito');
+
+    $t->get_ok(
+        '/me/tarefas',
+        {'x-api-key' => $session},
+        form => {modificado_apos => $epoch_start},
+    )->status_is(200, 'busca todas as tarefas')->json_is('/tarefas/0/checkbox_feito', '0');
+
+    $t->post_ok(
+        '/me/tarefas/batch',
+        {'x-api-key' => $session},
+        json => [
+            {
+                id     => $mfc1->id,
+                remove => 1,
+            }
+        ],
+    )->status_is(200, 'batch de removido com sucesso');
+
+    $t->get_ok(
+        '/me/tarefas',
+        {'x-api-key' => $session},
+        form => {modificado_apos => $epoch_start},
+      )->status_is(200, 'busca todas as tarefas')    #
+      ->json_is('/tarefas',           [])            #
+      ->json_is('/tarefas_removidas', [$mfc1->id]);
+
+
+    my $json = $t->post_ok(
+        '/me/tarefas/nova',
+        {'x-api-key' => $session},
+        form => {
+            titulo           => 'hello',
+            descricao        => 'world',
+            agrupador        => 'hey',
+            campo_livre      => '',                                          # pode enviar vazio
+            checkbox_contato => '1',
+            token            => $Penhas::Helpers::Cliente::NEW_TASK_TOKEN,
+            modificado_apos  => $epoch_start,
+        },
+      )->status_is(200, 'adicionada com sucesso')    #
+      ->json_has('/id')                              #
+      ->json_has('/message', 'hello')->tx->res->json;
+    my $tarefa_criada_id = $json->{id};
+
+    $t->post_ok(
+        '/me/tarefas/batch',
+        {'x-api-key' => $session},
+        json => [
+            {
+                id             => $tarefa_criada_id,
+                campo_livre    => {hey => 1, deep => [1, "yes", {}]},
+                checkbox_feito => 0,
+            },
+            {
+                id             => $tarefa_criada_id,
+                campo_livre    => '{}',
+                checkbox_feito => 0,
+            }
+        ],
+    )->status_is(200, 'sync em batch aceita json como objeto ou string');
+
+    $t->post_ok(
+        '/me/tarefas/batch',
+        {'x-api-key' => $session},
+        json => [
+            {
+                id             => $tarefa_criada_id,
+                campo_livre    => '{}',
+                checkbox_feito => 0,
+            },
+            {
+                id             => $tarefa_criada_id,
+                campo_livre    => 'ABC',
+                checkbox_feito => 0,
+            }
+        ],
+    )->status_is(400, 'sync com erro em batch recusa tudo');
+
+    $t->post_ok(
+        '/me/tarefas/batch',
+        {'x-api-key' => $session},
+        json => [
+            {
+                id             => $tarefa_criada_id,
+                campo_livre    => {},
+                checkbox_feito => 0,
+            }
+        ],
+    )->status_is(200, 'sync em batch aceita json livre mesmo se for hash vazio');
+
+    $t->get_ok(
+        '/me/tarefas',
+        {'x-api-key' => $session},
+        form => {modificado_apos => $epoch_start},
+      )->status_is(200, 'busca todas as tarefas')    #
+      ->json_is('/tarefas/0/campo_livre', {})                    #
+      ->json_is('/tarefas/0/tipo',        'checkbox_contato');
+
+    $t->post_ok(
+        '/me/tarefas/sync',
+        {'x-api-key' => $session},
+        form => {
+            id             => $tarefa_criada_id,
+            campo_livre    => '["abc", {"why": false}]',
+            checkbox_feito => 1,
+        },
+    )->status_is(204, 'sync com sucesso');
+
+    $t->get_ok(
+        '/me/tarefas',
+        {'x-api-key' => $session},
+        form => {modificado_apos => $epoch_start},
+      )->status_is(200, 'busca todas as tarefas')    #
+      ->json_is('/tarefas/0/checkbox_feito', '1')                              #
+      ->json_is('/tarefas/0/campo_livre',    ["abc", {why => JSON::false}]);
+
+
+    # refazendo o "quiz B5"
+    $ENV{MF_REDO_ADDR_QUESTIONNAIRE_ID} = 19;
+    $schema2->resultset('MfQuestionnaireRemoveTarefa')->search({questionnaire_id => 20})->delete();
+    $schema2->resultset('MfQuestionnaireRemoveTarefa')->create(
+        {
+            questionnaire_id => 20,
+            codigo_tarefa    => $tarefa_1_sistema->codigo
+        }
+    );
+    app->cliente_mf_add_tarefa_por_codigo(codigos => [$tarefa_1_sistema->codigo], user_obj => $cliente);
+
+    $json = $t->post_ok(
+        '/me/quiz',
+        {'x-api-key' => $session},
+        form => {session_id => $cliente->mf_redo_addr_session_id()},
+      )->status_is(200, 'chamada com sucesso')    #
+      ->tx->res->json;
+
+    my $first_msg  = $json->{quiz_session}{current_msgs}[0];
+    my $input_msg  = $json->{quiz_session}{current_msgs}[-1];
+    my $session_id = $json->{quiz_session}{session_id};
+    my $field_ref  = $json->{quiz_session}{current_msgs}[-1]{ref};
+
+    my $session_id = $json->{quiz_session}{session_id};
+
+    like $first_msg->{content}, "Você deseja refazer? (refazer)", "pergunta";
+
+    $json = $t->post_ok(
+        '/me/quiz',
+        {'x-api-key' => $session},
+        form => {
+            session_id => $session_id,
+            $field_ref => 'N'
+
+        }
+    )->status_is(200)->json_has('/quiz_session')->tx->res->json;
+
+    $first_msg  = $json->{quiz_session}{current_msgs}[0];
+    $input_msg  = $json->{quiz_session}{current_msgs}[-1];
+    $session_id = $json->{quiz_session}{session_id};
+    $field_ref  = $json->{quiz_session}{current_msgs}[-1]{ref};
+
+    ok $session_id, 'has session';
+
+    use DDP;
+    p $json;
+
+
+    $json = $t->post_ok(
+        '/me/quiz',
+        {'x-api-key' => $session},
+        form => {session_id => $cliente->mf_redo_addr_session_id()},
+      )->status_is(200, 'chamada com sucesso')    #
+      ->tx->res->json;
+use DDP; p $json;
+    my $new_session_id = $json->{quiz_session}{session_id};
+    ok $new_session_id > $session_id, 'has newer session id';
+
+    use DDP;
+    p $json;
+
+};
+
+done_testing();
+
+exit;

--- a/api/t/api/142-mf-quiz.t
+++ b/api/t/api/142-mf-quiz.t
@@ -1,0 +1,294 @@
+#!/usr/bin/perl
+# HARNESS-CONFLICTS CHAT
+
+use JSON;
+use Mojo::Base -strict;
+use FindBin qw($RealBin);
+use lib "$RealBin/../lib";
+use DateTime;
+use utf8;
+use Penhas::Test;
+use Penhas::Minion::Tasks::SendSMS;
+my $t = test_instance;
+use Business::BR::CPF qw/random_cpf/;
+use DateTime;
+use Penhas::Minion::Tasks::NewNotification;
+
+my $schema2 = $t->app->schema2;
+
+my $now_datetime = DateTime->now()->datetime(' ');
+
+AGAIN:
+my $random_cpf   = random_cpf();
+my $random_email = 'email' . $random_cpf . '@something.com';
+goto AGAIN if cpf_already_exists($random_cpf);
+
+$ENV{FILTER_QUESTIONNAIRE_IDS} = '99999';
+$ENV{SKIP_END_NEWS}            = '1';
+
+$Penhas::Helpers::Cliente::NEW_TASK_TOKEN = 'new-task';
+
+my @other_fields = (
+    raca        => 'branco',
+    app_version => 'Versao Ios ou Android, Modelo Celular, Versao do App',
+    dry         => 0,
+);
+
+my $nome_completo = 'test tarefa';
+
+get_schema->resultset('CpfCache')->find_or_create(
+    {
+        cpf_hashed  => cpf_hash_with_salt($random_cpf),
+        dt_nasc     => '1994-01-31',
+        nome_hashed => cpf_hash_with_salt(uc $nome_completo),
+        situacao    => '',
+    }
+);
+
+my ($cliente_id, $session, $cliente);
+
+subtest_buffered 'Cadastro com sucesso' => sub {
+    my $res = $t->post_ok(
+        '/signup',
+        form => {
+            nome_completo => $nome_completo,
+            apelido       => 'cliente A',
+            cpf           => $random_cpf,
+            email         => $random_email,
+            senha         => 'ARUKEAS SS2',
+            cep           => '12345678',
+            dt_nasc       => '1994-01-31',
+            @other_fields,
+            genero      => rand() > 0.5 ? 'Feminino' : 'MulherTrans',
+            nome_social => 'foo bar',
+        },
+    )->status_is(200)->tx->res->json;
+
+    $cliente_id = $res->{_test_only_id};
+    $session    = $res->{session};
+    $cliente    = $schema2->resultset('Cliente')->find($cliente_id);
+};
+
+on_scope_exit { user_cleanup(user_id => [$cliente_id,]); };
+
+
+$t->get_ok('/filter-skills', {'x-api-key' => $session})->status_is(200);
+
+db_transaction {
+
+    $ENV{ENABLE_MANUAL_FUGA} = 1;
+    my $me_perfil = $t->get_ok(
+        '/me',
+        {'x-api-key' => $session},
+        form => {},
+    )->status_is(200, '')->tx->res->json;
+
+    $t->app->cliente_mf_clear_tasks( user_obj => $cliente );
+
+    my $epoch_start = 0;
+
+    my $me_tarefas = $t->get_ok(
+        '/me/tarefas',
+        {'x-api-key' => $session},
+        form => {modificado_apos => $epoch_start},
+    )->status_is(200, 'busca todas as tarefas')->tx->res->json;
+
+    ok $me_tarefas->{mf_assistant}{quiz_session}{session_id}, 'has session-id';
+
+    subtest_buffered 'iniciando o questionario' => sub {
+
+        my $mf_sc = get_user_mf_sc($cliente_id);
+        is $mf_sc->status,                        'onboarding', 'status is onboarding';
+        is $mf_sc->current_clientes_quiz_session, undef,        'current_clientes_quiz_session is null';
+
+        my $json = $t->post_ok(
+            '/me/quiz',
+            {'x-api-key' => $session},
+            form => {
+                session_id => $me_tarefas->{mf_assistant}{quiz_session}{session_id},
+            }
+        )->status_is(200)->json_has('/quiz_session')->tx->res->json;
+
+        $mf_sc->discard_changes;
+        is $mf_sc->status, 'inProgress', 'status is inProgress';
+        is $mf_sc->completed_questionnaires_id, [], 'no completed_questionnaires_id';
+
+        my $first_msg  = $json->{quiz_session}{current_msgs}[0];
+        my $input_msg  = $json->{quiz_session}{current_msgs}[-1];
+        my $session_id = $json->{quiz_session}{session_id};
+        my $field_ref  = $json->{quiz_session}{current_msgs}[-1]{ref};
+
+        ok $session_id, 'has session';
+        like $first_msg->{content}, qr/bem-vinda ao Manual de Fuga do PenhaS./, "msg de bem vindo";
+        like $input_msg->{content}, qr/Separamos o conteúdo em quatro blocos/,  'escolha dos blocos';
+        like $field_ref, qr/^OC/, 'OC=only choice';
+
+        $json = $t->post_ok(
+            '/me/quiz',
+            {'x-api-key' => $session},
+            form => {
+                session_id => $me_tarefas->{mf_assistant}{quiz_session}{session_id},
+            }
+        )->status_is(200)->json_has('/quiz_session')->tx->res->json;
+
+        $first_msg = $json->{quiz_session}{current_msgs}[0];
+        like $first_msg->{content}, qr/existe um manual de fuga em andamento./, "erro pq mandou o session ID errado";
+
+        $json = $t->post_ok(
+            '/me/quiz',
+            {'x-api-key' => $session},
+            form => {
+                session_id => $session_id,
+                $field_ref => 0,
+            }
+        )->status_is(200)->json_has('/quiz_session')->tx->res->json;
+
+        $input_msg  = $json->{quiz_session}{current_msgs}[-1];
+        $session_id = $json->{quiz_session}{session_id};
+        $field_ref  = $json->{quiz_session}{current_msgs}[-1]{ref};
+
+        like $input_msg->{content}, qr/Você tem para onde ir?/, 'pergunta yesnomaybe';
+        is $input_msg->{type},      'yesnomaybe',               'sim não talvez';
+
+        ## chama o get do session no meio do quiz
+        my $me_tarefas_v2 = $t->get_ok(
+            '/me/tarefas',
+            {'x-api-key' => $session},
+            form => {modificado_apos => $epoch_start},
+        )->status_is(200, 'busca todas as tarefas')->tx->res->json;
+
+        $input_msg = $me_tarefas_v2->{mf_assistant}{quiz_session}{current_msgs}[-1];
+        like $input_msg->{content}, qr/Você tem para onde ir?/, 'pergunta yesnomaybe';
+use DDP; p $session_id;
+        $mf_sc->discard_changes;
+        is $mf_sc->status, 'inProgress', 'status is inProgress';
+        is $mf_sc->completed_questionnaires_id, [7], 'completed b0';
+
+        $json = $t->post_ok(
+            '/me/quiz',
+            {'x-api-key' => $session},
+            form => {
+                session_id => $session_id,
+                $field_ref => 'Y',
+            }
+        )->status_is(200)->json_has('/quiz_session')->tx->res->json;
+use DDP; p $session_id;
+        $mf_sc->discard_changes;
+        is $mf_sc->status, 'inProgress', 'status is inProgress';
+        is $mf_sc->completed_questionnaires_id, [7, 9], 'completed b0 and b1';
+
+        $first_msg = $json->{quiz_session}{current_msgs}[0];
+        $input_msg = $json->{quiz_session}{current_msgs}[-1];
+        $field_ref = $json->{quiz_session}{current_msgs}[-1]{ref};
+
+        like $first_msg->{content}, qr/Que bom que você não está sozinha/, 'campo display ok';
+        is $input_msg->{type},      'text',                                'campo livre - pergunta campo livre';
+
+        $json = $t->post_ok(
+            '/me/quiz',
+            {'x-api-key' => $session},
+            form => {
+                session_id => $session_id,
+                $field_ref => 'foo bar',
+            }
+        )->status_is(200)->json_has('/quiz_session')->tx->res->json;
+use DDP; p $json;
+
+        $mf_sc->discard_changes;
+        is $mf_sc->completed_questionnaires_id, [7, 9, 10], 'completed b0, b1 and b2';
+        is $mf_sc->status, 'inProgress', 'status is inProgress';
+
+        $first_msg = $json->{quiz_session}{current_msgs}[0];
+        $input_msg = $json->{quiz_session}{current_msgs}[-1];
+        $field_ref = $json->{quiz_session}{current_msgs}[-1]{ref};
+
+        like $first_msg->{content}, qr/teste mc/,      'teste de MC';
+        is $input_msg->{type},      'multiplechoices', 'multiplechoices';
+
+        $json = $t->post_ok(
+            '/me/quiz',
+            {'x-api-key' => $session},
+            form => {
+                session_id => $session_id,
+                $field_ref => '0,2',         # opção A e C
+            }
+        )->status_is(200)->json_has('/quiz_session')->tx->res->json;
+
+        $first_msg = $json->{quiz_session}{current_msgs}[0];
+        $input_msg = $json->{quiz_session}{current_msgs}[-1];
+        $field_ref = $json->{quiz_session}{current_msgs}[-1]{ref};
+        like $first_msg->{content}, qr/Até mais/, 'texto final';
+        is $input_msg->{type},      'button',     'botao para finalizar';
+
+        my $cliente_quiz_session = get_schema2->resultset('ClientesQuizSession')->find($session_id);
+        my $responses            = from_json($cliente_quiz_session->responses);
+
+        ok delete $responses->{start_time}, 'has start_time';
+
+        is $responses, {
+            b0_p0                => 'p0a',
+            b1_p1                => 'Y',
+            b2_primeira_e_ultima => 'foo bar',
+            MC_X                 => '[0,2]',
+            MC_X_json            => '["A","C"]',
+          },
+          'match expected responses';
+
+        $json = $t->post_ok(
+            '/me/quiz',
+            {'x-api-key' => $session},
+            form => {
+                session_id => $session_id,
+                $field_ref => 'ok',
+            }
+        )->status_is(200)->json_has('/quiz_session')->tx->res->json;
+
+        $mf_sc->discard_changes;
+        is $mf_sc->completed_questionnaires_id,   [], 'back to empty';
+        is $mf_sc->status,                        'completed', 'status is completed';
+        is $mf_sc->current_clientes_quiz_session, undef,       'current_clientes_quiz_session is back to null';
+
+        is $json->{quiz_session}{finished}, 1, 'finished=1';
+        ok $json->{quiz_session}{end_screen}, 'has end_screen';
+
+        # chama com o session (numerico) da not found
+        $t->post_ok(
+            '/me/quiz',
+            {'x-api-key' => $session},
+            form => {
+                session_id => $session_id,
+            }
+        )->status_is(400);
+
+        $me_tarefas = $t->get_ok(
+            '/me/tarefas',
+            {'x-api-key' => $session},
+            form => {modificado_apos => $epoch_start},
+        )->status_is(200, 'busca todas as tarefas')->tx->res->json;
+
+        $session_id = $me_tarefas->{mf_assistant}{quiz_session}{session_id};
+
+        $json = $t->post_ok(
+            '/me/quiz',
+            {'x-api-key' => $session},
+            form => {
+                session_id => $session_id,
+            }
+        )->status_is(200)->json_has('/quiz_session')->tx->res->json;
+        $first_msg = $json->{quiz_session}{current_msgs}[0];
+
+        like $first_msg->{content}, qr/bem-vinda/, 'refazendo o questionario';
+
+    };
+
+};
+
+sub get_user_mf_sc {
+    my ($cliente_id) = @_;
+
+    return get_schema2->resultset('ClienteMfSessionControl')->find({cliente_id => $cliente_id});
+}
+
+done_testing();
+
+exit;

--- a/api/t/lib/Penhas/Test.pm
+++ b/api/t/lib/Penhas/Test.pm
@@ -277,6 +277,7 @@ sub user_cleanup {
         TweetsReport
         MediaUpload
         PontoApoioSugestoesV2
+        MfClienteTarefa
         /
       )
     {


### PR DESCRIPTION
Adiciona funcionalidades para gerenciamento de tarefas e questionários no assistente de manual de fuga

- Implementa a criação, sincronização e remoção de tarefas associadas a clientes.
- Adiciona suporte para questionários relacionados ao assistente de manual de fuga, permitindo que os usuários respondam a perguntas e gerenciem suas tarefas.
- Cria novas rotas para manipulação de tarefas e questionários, incluindo endpoints para listar, adicionar e sincronizar tarefas.
- Introduz novos modelos e relacionamentos no banco de dados para suportar as novas funcionalidades, como `MfClienteTarefa`, `ClienteMfSessionControl`, e `MfTag`.
- Melhora a lógica de controle de sessão para o assistente, permitindo que os usuários refaçam questionários e gerenciem suas tarefas de forma mais eficiente.
- Adiciona testes para garantir a funcionalidade correta das novas implementações.