### PR TITLE
Adiciona sistema de badges para usuárias com suporte à localização

### DIFF
--- a/api/deploy_db/deploy/0020-circulopenhas.sql
+++ b/api/deploy_db/deploy/0020-circulopenhas.sql
@@ -1,0 +1,21 @@
+-- Deploy penhas:0020-circulopenhas to pg
+-- requires: 0019-municipality-sp
+BEGIN;
+
+CREATE TABLE badges (
+    id serial primary key,
+    code varchar(200) not null,
+    name varchar(200) not null,
+    description text not null,
+    image_url varchar(1000) not null,
+    linked_cep_cidade character varying(200),
+    created_on timestamp not null default now(),
+    modified_on timestamp not null default now()
+);
+
+ALTER TABLE cliente_tag ADD COLUMN badge_id integer references badges(id);
+
+ALTER TABLE cliente_tag ADD COLUMN valid_until timestamp without time zone not null default 'infinity';
+
+
+COMMIT;

--- a/api/deploy_db/deploy/0020-circulopenhas.sql
+++ b/api/deploy_db/deploy/0020-circulopenhas.sql
@@ -14,6 +14,7 @@ CREATE TABLE badges (
 );
 
 ALTER TABLE cliente_tag ADD COLUMN badge_id integer references badges(id);
+ALTER TABLE cliente_tag ALTER COLUMN mf_tag_id DROP NOT NULL;
 
 ALTER TABLE cliente_tag ADD COLUMN valid_until timestamp without time zone not null default 'infinity';
 

--- a/api/deploy_db/sqitch.plan
+++ b/api/deploy_db/sqitch.plan
@@ -5,3 +5,4 @@
 0002-configs [0001-db-init] 2020-04-11T19:26:08Z renato,,, <renato.santos@appcivico> # configs gerais e email
 0012-bot-twitter [0002-configs] 2021-05-31T17:53:34Z renato,,, <renato.santos@appcivico> # anon-quiz do twitter
 0019-municipality-sp [0012-bot-twitter] 2022-02-24T11:46:02Z renato,,, <renato.santos@appcivico> # cadastra sp para os testes
+0020-circulopenhas [0019-municipality-sp] 2025-01-30T11:56:07Z renato,,, <renato@renato-MS-7A34> # badges e outras tabelas de apoio para o circulo penhas

--- a/api/lib/Penhas/Controller/Me_Chat.pm
+++ b/api/lib/Penhas/Controller/Me_Chat.pm
@@ -44,8 +44,9 @@ sub me_chat_sessions {
     my $user_obj = $c->stash('user_obj');
 
     my $valid = $c->validate_request_params(
-        rows => {required => 0, type => 'Int'},
-        next_page => {required => 0, type => 'Str', max_length => 9999},
+        rows       => {required => 0, type => 'Int'},
+        cliente_id => {required => 0, type => 'Int',},
+        next_page  => {required => 0, type => 'Str', max_length => 9999},
     );
 
     my $ret = $c->chat_list_sessions(

--- a/api/lib/Penhas/Controller/Timeline.pm
+++ b/api/lib/Penhas/Controller/Timeline.pm
@@ -43,9 +43,9 @@ sub add_like {
     );
 
     my $tweet = $c->like_tweet(
-        id     => $c->stash('tweet')->{id},
-        user   => $c->stash('user'),
-        remove => exists $params->{remove} && $params->{remove} eq '1' ? 1 : 0,
+        id       => $c->stash('tweet')->{id},
+        user_obj => $c->stash('user_obj'),
+        remove   => exists $params->{remove} && $params->{remove} eq '1' ? 1 : 0,
     );
 
     return $c->render(
@@ -70,9 +70,9 @@ sub add_report {
     );
 
     my $tweet = $c->report_tweet(
-        id     => $c->stash('tweet')->{id},
-        user   => $c->stash('user'),
-        reason => $params->{reason}
+        id       => $c->stash('tweet')->{id},
+        user_obj => $c->stash('user_obj'),
+        reason   => $params->{reason}
     );
 
     return $c->render(
@@ -113,7 +113,6 @@ sub list {
         %$params,
         is_legacy => $is_legacy,
         os        => $os,
-        user      => $c->stash('user'),
         user_obj  => $c->stash('user_obj'),
     );
 

--- a/api/lib/Penhas/Helpers.pm
+++ b/api/lib/Penhas/Helpers.pm
@@ -19,6 +19,7 @@ use Penhas::Helpers::ChatSupport;
 use Penhas::Helpers::Notifications;
 use Penhas::Helpers::WebHelpers;
 use Penhas::Helpers::Cliente;
+use Penhas::Helpers::Badges;
 
 use Carp qw/croak confess/;
 
@@ -41,6 +42,7 @@ sub setup {
     Penhas::Helpers::Notifications::setup($c);
     Penhas::Helpers::WebHelpers::setup($c);
     Penhas::Helpers::Cliente::setup($c);
+    Penhas::Helpers::Badges::setup($c);
 
     state $kv = Penhas::KeyValueStorage->instance;
     $c->helper(kv                        => sub {$kv});

--- a/api/lib/Penhas/Helpers/Badges.pm
+++ b/api/lib/Penhas/Helpers/Badges.pm
@@ -1,0 +1,56 @@
+package Penhas::Helpers::Badges;
+use common::sense;
+use Carp qw/confess/;
+use utf8;
+
+use Penhas::Logger;
+use Penhas::Utils;
+
+sub setup {
+    my $self = shift;
+
+    $self->helper('cliente_add_badge' => sub { &cliente_add_badge(@_) });
+
+}
+
+sub cliente_add_badge {
+    my ($c, %opts) = @_;
+
+    my $badge_id = $opts{badge_id} or confess 'missing badge_id';
+    my $user     = $opts{user_obj} or confess 'missing user_obj';
+    return {} unless $user->is_female();
+
+
+    my $badge = $c->schema2->resultset('Badge')->find($badge_id);
+
+    die {
+        message => 'Badge não encontrada',
+        error   => 'badge_not_found'
+    } unless $badge;
+
+    my $badge_cliente = $c->schema2->resultset('ClienteTag')->search(
+        {
+            badge_id    => $badge_id,
+            cliente_id  => $user->id,
+            valid_until => {'>' => \'now()'}
+        }
+    )->next;
+    if (!$badge_cliente) {
+        $c->schema2->txn_do(
+            sub {
+                $c->schema2->resultset('ClienteTag')->create(
+                    {
+                        badge_id    => $badge_id,
+                        cliente_id  => $user->id,
+                        created_on  => \'now()',
+                        valid_until => 'infinity'
+                    }
+                );
+            }
+        );
+    }
+
+    return {};
+}
+
+1;

--- a/api/lib/Penhas/Helpers/ChatSupport.pm
+++ b/api/lib/Penhas/Helpers/ChatSupport.pm
@@ -138,6 +138,15 @@ sub _load_support_room {
         activity   => eval { $user_obj->clientes_app_activity->last_activity() } || '',
         apelido    => $user_obj->name_for_admin(),
         avatar_url => $ENV{AVATAR_SUPORTE_URL},
+
+        # admin ve todos os badges, mas sem o badges pq os admin não são Clientes (nao tem CEP)
+        badges => [
+            map { $_->badge->render() } $c->schema2->resultset('Cliente')->search_related(
+                'badges_ativos',
+                {cliente_id => $user_obj->id},
+                {prefetch   => 'badge'}
+            )->all
+        ],
       }
       : {
         blocked_me => 0,
@@ -145,6 +154,7 @@ sub _load_support_room {
         activity   => 'até 48hrs para resposta',
         apelido    => 'Suporte PenhaS',
         avatar_url => $ENV{AVATAR_SUPORTE_URL},
+        badges     => [],                          # suporte sem badges
       };
 
     my $meta = {

--- a/api/lib/Penhas/Schema2/Result/Badge.pm
+++ b/api/lib/Penhas/Schema2/Result/Badge.pm
@@ -55,6 +55,16 @@ __PACKAGE__->has_many(
 # Created by DBIx::Class::Schema::Loader v0.07049 @ 2025-01-30 12:15:18
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4LroHT+lBR80v2oGND5gHQ
 
+sub render {
+    my ($self) = @_;
+    return {
+        code        => $self->code,
+        name        => $self->name,
+        description => $self->description,
+        image_url   => $self->image_url,
+        style       => 'popup',
+    };
+}
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 1;

--- a/api/lib/Penhas/Schema2/Result/Badge.pm
+++ b/api/lib/Penhas/Schema2/Result/Badge.pm
@@ -1,0 +1,60 @@
+#<<<
+use utf8;
+package Penhas::Schema2::Result::Badge;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use strict;
+use warnings;
+
+use base 'Penhas::Schema::Base';
+__PACKAGE__->table("badges");
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "badges_id_seq",
+  },
+  "code",
+  { data_type => "varchar", is_nullable => 0, size => 200 },
+  "name",
+  { data_type => "varchar", is_nullable => 0, size => 200 },
+  "description",
+  { data_type => "text", is_nullable => 0 },
+  "image_url",
+  { data_type => "varchar", is_nullable => 0, size => 1000 },
+  "linked_cep_cidade",
+  { data_type => "varchar", is_nullable => 1, size => 200 },
+  "created_on",
+  {
+    data_type     => "timestamp",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "modified_on",
+  {
+    data_type     => "timestamp",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+);
+__PACKAGE__->set_primary_key("id");
+__PACKAGE__->has_many(
+  "cliente_tags",
+  "Penhas::Schema2::Result::ClienteTag",
+  { "foreign.badge_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+#>>>
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2025-01-30 12:15:18
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4LroHT+lBR80v2oGND5gHQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/api/lib/Penhas/Schema2/Result/Cliente.pm
+++ b/api/lib/Penhas/Schema2/Result/Cliente.pm
@@ -490,6 +490,28 @@ sub linked_location_badges {
     return \@badges;
 }
 
+sub check_location_badge_for_cidade {
+    my ($self, $cep_cidade) = @_;
+    return () unless $cep_cidade;
+
+    my $badge_locations = $self->linked_location_badges();
+    my @badges;
+
+    for my $badge (@$badge_locations) {
+        if ($badge->linked_cep_cidade() eq $cep_cidade) {
+            push @badges, {
+                description => 'Usuárias da cidade ' . $cep_cidade,
+                image_url   => '',
+                name        => 'Usuária da sua região',
+                code        => 'GEO:CITY',
+                style       => 'inline',
+            };
+        }
+    }
+
+    return @badges;
+}
+
 sub has_module {
     my $self   = shift;
     my $module = shift || confess 'missing module name';

--- a/api/lib/Penhas/Schema2/Result/ClienteTag.pm
+++ b/api/lib/Penhas/Schema2/Result/ClienteTag.pm
@@ -21,7 +21,7 @@ __PACKAGE__->add_columns(
   "cliente_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "mf_tag_id",
-  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "created_on",
   {
     data_type     => "timestamp",
@@ -57,12 +57,17 @@ __PACKAGE__->belongs_to(
   "mf_tag",
   "Penhas::Schema2::Result::MfTag",
   { id => "mf_tag_id" },
-  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "CASCADE",
+    on_update     => "NO ACTION",
+  },
 );
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2025-01-30 12:15:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CvoM4Rfae3lYNJAY6szobw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2025-02-06 01:37:32
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:yTIzUhcjfcLUsK0Twtj9iQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/api/lib/Penhas/Schema2/Result/ClienteTag.pm
+++ b/api/lib/Penhas/Schema2/Result/ClienteTag.pm
@@ -29,9 +29,24 @@ __PACKAGE__->add_columns(
     is_nullable   => 0,
     original      => { default_value => \"now()" },
   },
+  "badge_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
+  "valid_until",
+  { data_type => "timestamp", default_value => "infinity", is_nullable => 0 },
 );
 __PACKAGE__->set_primary_key("id");
 __PACKAGE__->add_unique_constraint("unique_cliente_tag", ["cliente_id", "mf_tag_id"]);
+__PACKAGE__->belongs_to(
+  "badge",
+  "Penhas::Schema2::Result::Badge",
+  { id => "badge_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
 __PACKAGE__->belongs_to(
   "cliente",
   "Penhas::Schema2::Result::Cliente",
@@ -46,8 +61,8 @@ __PACKAGE__->belongs_to(
 );
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2024-10-11 11:03:30
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:rWi3XgJORP+WZzicv8nO2w
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2025-01-30 12:15:18
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CvoM4Rfae3lYNJAY6szobw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/api/t/lib/Penhas/Test.pm
+++ b/api/t/lib/Penhas/Test.pm
@@ -38,7 +38,7 @@ package Mojo::Transaction::Role::PrettyDebug {
 package Penhas::Test;
 use Mojo::Base -strict;
 use Test2::V0;
-use Test2::Plugin::BailOnFail;
+#use Test2::Plugin::BailOnFail;
 use Test2::Tools::Subtest qw(subtest_buffered subtest_streamed);
 use Test2::Mock;
 use Test::Mojo;


### PR DESCRIPTION
Adiciona um novo sistema de badges (distintivos) para as usuárias da plataforma, com suporte especial para badges baseados em localização.

Principais mudanças:
- Nova tabela `badges` para armazenar os distintivos com campos para código, nome, descrição, URL da imagem e cidade vinculada
- Integração de badges nos tweets e perfis de usuárias
- Suporte para badges de localização que são exibidos quando usuárias são da mesma cidade
- Alteração na tabela `cliente_tag` para suportar badges com prazo de validade
- Otimização no carregamento de badges em listagens de tweets e chats

Mudanças técnicas:
- Nova migração (0020-circulopenhas.sql) para criar a tabela badges
- Adição do módulo `Penhas::Helpers::Badges` para gerenciar badges
- Implementação de métodos `render` para padronizar a exibição de badges
- Suporte a dois tipos de visualização de badges: popup (padrão) e inline (para badges de localização)
- Atualização dos testes para cobrir as novas funcionalidades

Esta feature permite uma melhor personalização e contextualização das interações entre usuárias, especialmente para identificar participantes da mesma região.