### PR TITLE
Fix Badge Geo para Voluntárias

### DIFF
--- a/api/lib/Penhas/Schema2/Result/Cliente.pm
+++ b/api/lib/Penhas/Schema2/Result/Cliente.pm
@@ -414,9 +414,9 @@ __PACKAGE__->has_many(
 
         return {
             "$args->{self_alias}.modo_anonimo_ativo" => \' = false',
-            "$args->{foreign_alias}.cliente_id"        => {-ident => "$args->{self_alias}.id"},
-            "$args->{foreign_alias}.valid_until"       => {'>'    => \'now()'},
-            "$args->{foreign_alias}.badge_id"          => {'!='   => undef},
+            "$args->{foreign_alias}.cliente_id"      => {-ident => "$args->{self_alias}.id"},
+            "$args->{foreign_alias}.valid_until"     => {'>'    => \'now()'},
+            "$args->{foreign_alias}.badge_id"        => {'!='   => undef},
         };
     }
 );
@@ -502,11 +502,16 @@ sub check_location_badge_for_cidade {
     my ($self, $cep_cidade, $block) = @_;
     return () unless $cep_cidade;
 
+    my $self_cidade = $self->cep_cidade();
+
+    # pula se o cliente não tem cidade cadastrada ou se a cidade do cliente é diferente da cidade do cep do tweets
+    return () if $self_cidade && $self_cidade ne $cep_cidade;
+
     my $badge_locations = $self->linked_location_badges();
     my @badges;
 
     for my $badge (@$badge_locations) {
-        if ($badge->linked_cep_cidade() eq $cep_cidade) {
+        if ($badge->linked_cep_cidade() eq $cep_cidade) {    # testa a cidade do badge
             push @badges, {
                 description => 'Usuária da sua região',
                 image_url   => $ENV{'PENHAS_DEFAULT_BADGE_' . uc($badge->code()) . '_ICON_URL'}


### PR DESCRIPTION
## Problema Principal

O problema principal estava relacionado à exibição incorreta (ou falta de exibição) dos badges de localização entre usuárias da mesma cidade, especialmente para voluntárias. Isso afetava:

1. A visualização de badges no chat
2. A visualização de badges na timeline
3. O comportamento quando usuárias mudavam de cidade

## Alterações Realizadas

### 1. Função `_format_chat_badges`

- Foi adicionado um novo parâmetro `$other_cep_cidade` para verificar a cidade atual da outra usuária
- Removida a condição que restringia a verificação apenas para usuárias no modo anônimo (`$user_obj->modo_anonimo_ativo`)
- Adicionada verificação adicional para garantir que a cidade atual da usuária corresponda à cidade do badge, evitando mostrar badges de localização para usuárias que mudaram de cidade

### 2. Função `_format_db_badges` na Timeline

- Similar às alterações no chat, foi adicionado o parâmetro `$cliente_cep_cidade`
- Removida a restrição de modo anônimo
- Adicionada verificação explícita para garantir que a cidade do usuário e a cidade do cliente sejam iguais

### 3. Função `check_location_badge_for_cidade`

- Adicionada verificação prévia para pular a verificação se a cidade do cliente for diferente da cidade do CEP do tweet

### 4. Alterações na Exibição da Timeline

- Adicionada condição para não mostrar badges quando o avatar é do sistema Penhas
- Adicionada instrução para pular a exibição de badges quando o post é anônimo

### 5. Alterações nos Métodos de Listagem

- Em `list_tweets`, o valor mínimo de linhas foi alterado de 10 para 1, permitindo requisições com menos resultados

## Resumo das Correções

1. **Correção da lógica de exibição de badges**: Os badges de localização agora são exibidos corretamente para usuárias da mesma cidade, independente do modo anônimo.

2. **Verificação de cidade atual**: Adicionadas verificações para garantir que a cidade atual das usuárias seja considerada, evitando mostrar badges para quem mudou de cidade.

3. **Tratamento de casos especiais**: Melhorado o tratamento para posts anônimos e avatares do sistema.

Estas alterações garantem que o recurso de identificação de usuárias da mesma região funcione conforme esperado, corrigindo o "bug" mencionado nas conversas onde voluntárias não estavam visualizando corretamente os badges de localização de outras usuárias.