### PR TITLE
security: add HTTP security headers to all API responses

### DIFF
--- a/api/lib/Penhas.pm
+++ b/api/lib/Penhas.pm
@@ -83,6 +83,33 @@ sub startup {
         }
     );
 
+    # Security headers - adicionados em todas as respostas HTTP.
+    # Ref: OWASP Secure Headers Project
+    # Ticket: security/add-response-security-headers
+    $self->hook(
+        after_dispatch => sub {
+            my $c       = shift;
+            my $headers = $c->res->headers;
+
+            $headers->header('X-Frame-Options'       => 'DENY');
+            $headers->header('X-Content-Type-Options' => 'nosniff');
+            $headers->header('X-XSS-Protection'       => '0');
+            $headers->header('Content-Security-Policy' => "default-src 'self'; frame-ancestors 'none'");
+            $headers->header('Referrer-Policy'         => 'strict-origin-when-cross-origin');
+            $headers->header('Permissions-Policy'      => 'geolocation=(), camera=(), microphone=()');
+
+            # HSTS apenas quando a conexão é (ou foi proxied como) HTTPS
+            my $proto = $c->req->headers->header('X-Forwarded-Proto') || '';
+            if ($c->req->is_secure || $proto eq 'https') {
+                $headers->header('Strict-Transport-Security' => 'max-age=31536000; includeSubDomains');
+            }
+
+            # Cache-Control para respostas API - não sobrescreve valores já definidos por controllers
+            if (!$headers->cache_control) {
+                $headers->cache_control('no-store');
+            }
+        }
+    );
 
 }
 

--- a/api/t/api/160-security-headers.t
+++ b/api/t/api/160-security-headers.t
@@ -1,0 +1,75 @@
+use Mojo::Base -strict;
+use FindBin qw($RealBin);
+use lib "$RealBin/../lib";
+
+use Test2::V0;
+use Penhas::Test;
+
+my $t = test_instance;
+
+subtest 'API responses include security headers' => sub {
+
+    $t->get_ok('/web/faq')->status_is(200);
+
+    my $headers = $t->tx->res->headers;
+
+    is $headers->header('X-Frame-Options'),       'DENY',    'X-Frame-Options is DENY';
+    is $headers->header('X-Content-Type-Options'), 'nosniff', 'X-Content-Type-Options is nosniff';
+    is $headers->header('X-XSS-Protection'),       '0',       'X-XSS-Protection is 0 (modern recommendation)';
+
+    like $headers->header('Content-Security-Policy'), qr/default-src 'self'/,
+      'CSP includes default-src self';
+    like $headers->header('Content-Security-Policy'), qr/frame-ancestors 'none'/,
+      'CSP includes frame-ancestors none';
+
+    is $headers->header('Referrer-Policy'), 'strict-origin-when-cross-origin',
+      'Referrer-Policy is strict-origin-when-cross-origin';
+
+    like $headers->header('Permissions-Policy'), qr/geolocation=\(\)/,
+      'Permissions-Policy restricts geolocation';
+    like $headers->header('Permissions-Policy'), qr/camera=\(\)/,
+      'Permissions-Policy restricts camera';
+    like $headers->header('Permissions-Policy'), qr/microphone=\(\)/,
+      'Permissions-Policy restricts microphone';
+};
+
+subtest 'security headers present on termos-de-uso' => sub {
+
+    $t->get_ok('/web/termos-de-uso')->status_is(200);
+
+    my $headers = $t->tx->res->headers;
+
+    is $headers->header('X-Frame-Options'),       'DENY',    'X-Frame-Options on termos-de-uso';
+    is $headers->header('X-Content-Type-Options'), 'nosniff', 'X-Content-Type-Options on termos-de-uso';
+};
+
+subtest 'Cache-Control defaults to no-store for API responses' => sub {
+
+    $t->get_ok('/web/faq')->status_is(200);
+
+    is $t->tx->res->headers->cache_control, 'no-store',
+      'Cache-Control is no-store by default';
+};
+
+subtest 'HSTS header is absent without HTTPS' => sub {
+
+    $t->get_ok('/web/faq')->status_is(200);
+
+    my $hsts = $t->tx->res->headers->header('Strict-Transport-Security');
+    ok !defined $hsts, 'HSTS header not set for plain HTTP request';
+};
+
+subtest 'HSTS header present when X-Forwarded-Proto is https' => sub {
+
+    $t->get_ok('/web/faq', {'X-Forwarded-Proto' => 'https'})->status_is(200);
+
+    like $t->tx->res->headers->header('Strict-Transport-Security'),
+      qr/max-age=31536000/,
+      'HSTS header set when proxied as HTTPS';
+
+    like $t->tx->res->headers->header('Strict-Transport-Security'),
+      qr/includeSubDomains/,
+      'HSTS includes includeSubDomains directive';
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

- Adds an `after_dispatch` Mojolicious hook in `Penhas.pm` that sets security headers on **every HTTP response**, mitigating common web attacks per [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/)
- Includes test file `160-security-headers.t` covering all headers and conditional HSTS logic
- `Cache-Control: no-store` is set as default but **does not override** values already set by controllers (e.g. `StaticCache` plugin for static assets, `MediaDownload` for media)

### Headers added

| Header | Value | Purpose |
|--------|-------|---------|
| `X-Frame-Options` | `DENY` | Clickjacking protection |
| `X-Content-Type-Options` | `nosniff` | MIME type sniffing prevention |
| `X-XSS-Protection` | `0` | Disables legacy XSS filter (modern recommendation) |
| `Content-Security-Policy` | `default-src 'self'; frame-ancestors 'none'` | XSS/injection mitigation |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referer header control |
| `Permissions-Policy` | `geolocation=(), camera=(), microphone=()` | Restricts sensitive browser APIs |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Forces HTTPS (**conditional** — only when `X-Forwarded-Proto: https` or `is_secure`) |
| `Cache-Control` | `no-store` | Default for API responses (sensitive data) |

### Before / After

**Before:** Zero security headers on any response.
**After:** All responses include protective headers per OWASP guidelines.

## Test plan

- [ ] Run `yath test -PPenhas -Ilib t/api/160-security-headers.t` — new test covering all headers
- [ ] Run full test suite `yath test -j 8 -PPenhas -Ilib t/` — no regressions
- [ ] Verify media download endpoints still return their own `Cache-Control` (not overridden by `no-store`)
- [ ] Verify `/web/faq`, `/web/termos-de-uso`, `/web/politica-privacidade` responses include all headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)