### PR TITLE
fix(ponto_apoio): auto-resync sequence + retry on duplicate PK

### DIFF
--- a/api/lib/Penhas/Controller.pm
+++ b/api/lib/Penhas/Controller.pm
@@ -146,10 +146,61 @@ sub _reply_exception {
         {
             $c->app->log->info('Exception treated: ' . $an_error->{msg});
 
+            my ($constraint) = $an_error->{msg} =~ /unique constraint "([^"]+)"/;
+            my ($field, $value) = $an_error->{msg} =~ /Key \(([^)]+)\)=\(([^)]*)\) already exists/;
+            my ($table) = $an_error->{msg} =~ /(?:INSERT INTO|UPDATE)\s+"?([a-zA-Z0-9_.]+)"?/;
+
+            if (!$field && $constraint) {
+                eval {
+                    my $schema = $c->can('schema2') ? $c->schema2 : ($c->can('schema') ? $c->schema : undef);
+                    if ($schema) {
+                        my $cols = $schema->storage->dbh_do(
+                            sub {
+                                my ($storage, $dbh) = @_;
+                                return $dbh->selectcol_arrayref(
+                                    q{
+                                        SELECT a.attname
+                                          FROM pg_constraint c
+                                          JOIN pg_attribute a
+                                            ON a.attrelid = c.conrelid
+                                           AND a.attnum   = ANY(c.conkey)
+                                         WHERE c.conname = ?
+                                         ORDER BY array_position(c.conkey, a.attnum)
+                                    },
+                                    undef, $constraint
+                                );
+                            }
+                        );
+                        $field = join(', ', @$cols) if $cols && @$cols;
+                    }
+                    1;
+                } or do {
+                    $c->app->log->warn('duplicate_key_violation: failed to resolve constraint columns: ' . $@);
+                };
+            }
+
+            my $message = 'You violated an unique constraint! Please verify your input fields and try again.';
+            if ($field && defined $value) {
+                $message = sprintf(
+                    'Duplicate value for field "%s" (value: "%s"). This record already exists.',
+                    $field, $value
+                );
+            }
+            elsif ($field) {
+                $message = sprintf('Duplicate value for field "%s". This record already exists.', $field);
+            }
+            elsif ($constraint) {
+                $message = sprintf('Duplicate value violates constraint "%s". This record already exists.', $constraint);
+            }
+
             return $c->render(
                 json => {
-                    error   => 'duplicate_key_violation',
-                    message => 'You violated an unique constraint! Please verify your input fields and try again.'
+                    error      => 'duplicate_key_violation',
+                    message    => $message,
+                    field      => $field,
+                    value      => $value,
+                    constraint => $constraint,
+                    table      => $table,
                 },
                 status => 400,
             );

--- a/api/lib/Penhas/Controller/Admin/PontoApoio.pm
+++ b/api/lib/Penhas/Controller/Admin/PontoApoio.pm
@@ -440,45 +440,89 @@ sub try_publish_pa {
           if $valid->{$field} && $valid->{$field} !~ /^\d{2}\:\d{2}$/a;
     }
 
-    $c->schema->txn_do(
-        sub {
-            $valid->{ja_passou_por_moderacao} = 1;
+    my $do_approve = sub {
+        $c->schema->txn_do(
+            sub {
+                $valid->{ja_passou_por_moderacao} = 1;
 
-            $valid->{status}     = 'active';
-            $valid->{created_on} = \'now()';
-            $valid->{updated_at} = \'now()';
-            $valid->{cliente_id} = $row->get_column('cliente_id');
+                $valid->{status}     = 'active';
+                $valid->{created_on} = \'now()';
+                $valid->{updated_at} = \'now()';
+                $valid->{cliente_id} = $row->get_column('cliente_id');
 
-            my $pa = $c->schema2->resultset('PontoApoio')->create($valid);
+                my $pa = $c->schema2->resultset('PontoApoio')->create($valid);
 
-            my @auto_inserir
-              = $c->schema2->resultset('PontoApoioProjeto')->search({auto_inserir => 1}, {columns => ['id']});
+                my @auto_inserir
+                  = $c->schema2->resultset('PontoApoioProjeto')->search({auto_inserir => 1}, {columns => ['id']});
 
-            for my $proj (@auto_inserir) {
-                $c->schema2->resultset('PontoApoio2projeto')->create(
+                for my $proj (@auto_inserir) {
+                    $c->schema2->resultset('PontoApoio2projeto')->create(
+                        {
+                            ponto_apoio_id         => $pa->id,
+                            ponto_apoio_projeto_id => $proj->id,
+                        }
+                    );
+                }
+
+                $c->tick_ponto_apoio_index();
+
+                $row->update(
                     {
-                        ponto_apoio_id         => $pa->id,
-                        ponto_apoio_projeto_id => $proj->id,
+                        metainfo => to_json(
+                            {
+                                %{from_json($row->metainfo())},
+                                ponto_apoio_id => $pa->id,
+                                approved_by    => $c->stash('admin_user')->id,
+                            }
+                        ),
+                        status => 'approved',
                     }
                 );
             }
+        );
+    };
 
-            $c->tick_ponto_apoio_index();
+    my $attempts = 0;
+    while (1) {
+        $attempts++;
+        my $ok = eval { $do_approve->(); 1 };
+        last if $ok;
+        my $err = $@;
 
-            $row->update(
-                {
-                    metainfo => to_json(
-                        {
-                            %{from_json($row->metainfo())},
-                            ponto_apoio_id => $pa->id,
-                            approved_by    => $c->stash('admin_user')->id,
+        my $is_dup_pk
+          = ref $err eq 'DBIx::Class::Exception'
+          && $err->{msg}
+          && $err->{msg} =~ /duplicate key value violates unique constraint/i
+          && $err->{msg} =~ /Key \(id\)=/;
+
+        if ($is_dup_pk && $attempts < 2) {
+            my ($table) = $err->{msg} =~ /(?:INSERT INTO|UPDATE)\s+"?([a-zA-Z0-9_.]+)"?/;
+            $table //= 'ponto_apoio';
+            $table =~ s/^public\.//;
+            if ($table =~ /^[a-zA-Z_][a-zA-Z0-9_]*$/) {
+                eval {
+                    $c->schema2->storage->dbh_do(
+                        sub {
+                            my ($storage, $dbh) = @_;
+                            my $tq = $dbh->quote_identifier($table);
+                            $dbh->do(
+                                "SELECT setval(pg_get_serial_sequence(?, 'id'),
+                                               GREATEST(COALESCE((SELECT MAX(id) FROM $tq), 1), 1))",
+                                undef, $table
+                            );
                         }
-                    ),
-                    status => 'approved',
-                }
-            );
+                    );
+                    $c->app->log->info("auto-resynced sequence for $table, retrying approve");
+                    1;
+                } or do {
+                    $c->app->log->warn("seq resync failed for $table: $@");
+                    die $err;
+                };
+                next;
+            }
         }
-    );
+        die $err;
+    }
 
     $c->flash_to_redis({success_message => 'Ponto de Apoio registrado!'});
     $c->redirect_to('/admin/');


### PR DESCRIPTION
PG sequence drifts when bulk imports (Directus, restores) insert explicit IDs without setval. Approval flow was failing repeatedly with duplicate_key_violation until user refresh.

Changes:
- Admin/PontoApoio.pm: wrap approval txn_do in retry loop. On dup PK, setval(seq, MAX(id)) in autocommit and re-run the txn (max 2 attempts). Self-heals without user intervention.
- Controller.pm: enrich duplicate_key_violation response with field/value/constraint/table parsed from PG error. Falls back to pg_constraint catalog lookup when DETAIL is missing.